### PR TITLE
Integrate React Bits animations across site

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,10 +3,13 @@ import { Menu, X } from "lucide-react";
 import { useState } from "react";
 import { Button } from "./ui/button";
 import { motion, AnimatePresence } from "framer-motion";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { InfiniteMenu } from "@/components/reactbits/InfiniteMenu";
 
 export const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const links = [
     { href: "/", label: "Home" },
@@ -18,7 +21,20 @@ export const Navigation = () => {
   const isActive = (path: string) => location.pathname === path;
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-lg border-b border-border">
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-background/70 backdrop-blur-xl border-b border-border/60">
+      {!prefersReducedMotion && (
+        <svg className="pointer-events-none absolute h-0 w-0" aria-hidden>
+          <filter id="gooey-nav">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
+            <feColorMatrix
+              in="blur"
+              mode="matrix"
+              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
+            />
+            <feBlend in="SourceGraphic" />
+          </filter>
+        </svg>
+      )}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
@@ -29,27 +45,33 @@ export const Navigation = () => {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
-            {links.map((link) => (
-              <Link
-                key={link.href}
-                to={link.href}
-                className={`text-fluid-sm font-medium transition-colors relative ${
-                  isActive(link.href)
-                    ? "text-primary"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                {link.label}
-                {isActive(link.href) && (
-                  <motion.div
-                    layoutId="activeTab"
-                    className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-primary"
-                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                  />
-                )}
-              </Link>
-            ))}
+          <div className="hidden md:flex items-center justify-center">
+            <div
+              className="relative flex items-center gap-2 rounded-full bg-background/30 px-3 py-1 shadow-[0_0_0_1px_rgba(99,102,241,0.15)] backdrop-blur-lg"
+              style={prefersReducedMotion ? undefined : { filter: "url(#gooey-nav)" }}
+            >
+              {links.map((link) => {
+                const active = isActive(link.href);
+                return (
+                  <Link
+                    key={link.href}
+                    to={link.href}
+                    className="relative overflow-hidden rounded-full px-4 py-2 text-fluid-sm font-medium text-foreground/80 transition-all"
+                  >
+                    {!prefersReducedMotion && active && (
+                      <motion.span
+                        layoutId="gooey-bubble"
+                        className="absolute inset-0 -z-10 rounded-full bg-primary/30 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]"
+                        transition={{ type: "spring", stiffness: 260, damping: 24 }}
+                      />
+                    )}
+                    <span className={active ? "text-primary-foreground" : "hover:text-foreground transition-colors"}>
+                      {link.label}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
           </div>
 
           {/* Mobile Menu Button */}
@@ -72,23 +94,10 @@ export const Navigation = () => {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            className="md:hidden bg-card border-t border-border"
+            className="md:hidden bg-card/95 border-t border-border backdrop-blur-lg"
           >
-            <div className="container mx-auto px-4 py-4 space-y-3">
-              {links.map((link) => (
-                <Link
-                  key={link.href}
-                  to={link.href}
-                  onClick={() => setIsOpen(false)}
-                  className={`block px-4 py-2 rounded-lg text-fluid-sm font-medium transition-colors ${
-                    isActive(link.href)
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                  }`}
-                >
-                  {link.label}
-                </Link>
-              ))}
+            <div className="container mx-auto px-4 py-4">
+              <InfiniteMenu items={links} onNavigate={() => setIsOpen(false)} />
             </div>
           </motion.div>
         )}

--- a/src/components/reactbits/GlassIcon.tsx
+++ b/src/components/reactbits/GlassIcon.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type GlassIconProps = {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  href?: string;
+  className?: string;
+};
+
+export const GlassIcon = ({ icon, title, description, href, className }: GlassIconProps) => {
+  const content = (
+    <div
+      className={cn(
+        "group relative flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-left",
+        "shadow-[0_0_1px_rgba(255,255,255,0.4)] backdrop-blur-xl transition-all duration-300",
+        "hover:border-primary/40 hover:bg-primary/10",
+        className
+      )}
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 text-primary shadow-inner">
+        {icon}
+      </div>
+      <div className="space-y-1">
+        <p className="font-semibold text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-primary/5" />
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return (
+      <a href={href} className="no-underline" target={href.startsWith("http") ? "_blank" : undefined} rel="noreferrer">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+};

--- a/src/components/reactbits/InfiniteMenu.tsx
+++ b/src/components/reactbits/InfiniteMenu.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { cn } from "@/lib/utils";
+
+type InfiniteMenuProps = {
+  items: { href: string; label: string }[];
+  onNavigate?: () => void;
+};
+
+export const InfiniteMenu = ({ items, onNavigate }: InfiniteMenuProps) => {
+  const location = useLocation();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const menuItems = useMemo(
+    () => (prefersReducedMotion ? items : [...items, ...items]),
+    [items, prefersReducedMotion]
+  );
+
+  return (
+    <div className="relative overflow-hidden">
+      <div
+        className={cn(
+          "flex flex-col gap-2 py-2",
+          prefersReducedMotion ? "" : "animate-scroll-vertical",
+        )}
+      >
+        {menuItems.map((item, index) => {
+          const active = location.pathname === item.href;
+          return (
+            <Link
+              key={`${item.href}-${index}`}
+              to={item.href}
+              onClick={onNavigate}
+              className={cn(
+                "block rounded-xl px-4 py-3 text-sm font-medium transition-all",
+                active
+                  ? "bg-primary text-primary-foreground shadow-lg"
+                  : "bg-card/60 text-muted-foreground hover:bg-muted/80 hover:text-foreground",
+              )}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/reactbits/PixelCard.tsx
+++ b/src/components/reactbits/PixelCard.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+type PixelCardProps = {
+  image: string;
+  title: string;
+  subtitle?: string;
+  footer?: ReactNode;
+  className?: string;
+};
+
+export const PixelCard = ({ image, title, subtitle, footer, className }: PixelCardProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  return (
+    <div
+      className={cn(
+        "group relative overflow-hidden rounded-2xl border border-border/60 bg-card",
+        "transition-all duration-500 hover:border-primary/60 hover:shadow-lg",
+        className
+      )}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <img src={image} alt={title} className="h-full w-full object-cover" loading="lazy" />
+        {!prefersReducedMotion && (
+          <div className="absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
+            <div
+              className="absolute inset-0"
+              style={{
+                backgroundImage:
+                  "linear-gradient(135deg, rgba(99,102,241,0.35) 0%, transparent 60%), repeating-linear-gradient(90deg, rgba(17,17,17,0.15) 0px, rgba(17,17,17,0.15) 1px, transparent 1px, transparent 4px)",
+                mixBlendMode: "screen",
+              }}
+            />
+          </div>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/20 to-transparent" />
+      </div>
+
+      <div className="space-y-3 p-6">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-primary/80">{subtitle}</p>
+          <h3 className="text-fluid-xl font-semibold text-foreground">{title}</h3>
+        </div>
+        {footer && <div className="text-sm text-muted-foreground">{footer}</div>}
+      </div>
+    </div>
+  );
+};

--- a/src/components/reactbits/RippleGrid.tsx
+++ b/src/components/reactbits/RippleGrid.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+interface RippleGridProps {
+  className?: string;
+  color?: string;
+  speed?: number;
+}
+
+export const RippleGrid = ({ className, color = "rgba(99,102,241,0.25)", speed = 6 }: RippleGridProps) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || prefersReducedMotion) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    let animationFrame = 0;
+    const resize = () => {
+      canvas.width = canvas.clientWidth;
+      canvas.height = canvas.clientHeight;
+    };
+    resize();
+
+    const draw = (time: number) => {
+      const width = canvas.width;
+      const height = canvas.height;
+      context.clearRect(0, 0, width, height);
+
+      const gridSize = 48;
+      const amplitude = 12;
+      const frequency = 0.002 * speed;
+      const wave = Math.sin(time * 0.001 * speed);
+
+      for (let x = 0; x < width + gridSize; x += gridSize) {
+        for (let y = 0; y < height + gridSize; y += gridSize) {
+          const offset = Math.sin((x + y) * frequency + wave) * amplitude;
+          context.beginPath();
+          context.strokeStyle = color;
+          context.lineWidth = 1;
+          context.rect(x - offset, y - offset, gridSize, gridSize);
+          context.stroke();
+        }
+      }
+
+      animationFrame = requestAnimationFrame(draw);
+    };
+
+    animationFrame = requestAnimationFrame(draw);
+
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+    };
+  }, [color, prefersReducedMotion, speed]);
+
+  if (prefersReducedMotion) {
+    return <div className={className} aria-hidden style={{ backgroundImage: "linear-gradient(135deg, rgba(99,102,241,0.1), transparent)" }} />;
+  }
+
+  return <canvas ref={canvasRef} className={className} aria-hidden />;
+};

--- a/src/components/reactbits/RollingGallery.tsx
+++ b/src/components/reactbits/RollingGallery.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { cn } from "@/lib/utils";
+
+type RollingGalleryItem = {
+  id: string;
+  image: string;
+  title: string;
+  subtitle?: string;
+};
+
+type RollingGalleryProps = {
+  items: RollingGalleryItem[];
+  className?: string;
+  speed?: number;
+};
+
+export const RollingGallery = ({ items, className, speed = 30 }: RollingGalleryProps) => {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    if (prefersReducedMotion || !trackRef.current) return;
+
+    const track = trackRef.current;
+    const animation = track.animate(
+      [
+        { transform: "translateX(0)" },
+        { transform: "translateX(-50%)" },
+      ],
+      {
+        duration: speed * 1000,
+        iterations: Infinity,
+        easing: "linear",
+      }
+    );
+
+    return () => animation.cancel();
+  }, [prefersReducedMotion, speed]);
+
+  const galleryItems = prefersReducedMotion ? items : [...items, ...items];
+
+  return (
+    <div className={cn("relative overflow-hidden rounded-3xl border border-border/60 bg-card/80", className)}>
+      <div className="absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-background via-background/40 to-transparent pointer-events-none" />
+      <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background via-background/40 to-transparent pointer-events-none" />
+
+      <div
+        ref={trackRef}
+        className={cn(
+          "flex w-max gap-8 py-8",
+          prefersReducedMotion ? "mx-auto flex-wrap justify-center" : "",
+        )}
+        style={prefersReducedMotion ? undefined : { willChange: "transform" }}
+      >
+        {galleryItems.map((item, index) => (
+          <figure
+            key={`${item.id}-${index}`}
+            className="relative h-56 w-64 overflow-hidden rounded-2xl border border-border/60 bg-muted/20"
+          >
+            <img
+              src={item.image}
+              alt={item.title}
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-4 text-sm">
+              <p className="font-medium text-foreground">{item.title}</p>
+              {item.subtitle && <p className="text-xs text-muted-foreground">{item.subtitle}</p>}
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/reactbits/SilkBackground.tsx
+++ b/src/components/reactbits/SilkBackground.tsx
@@ -1,0 +1,160 @@
+import { forwardRef, useLayoutEffect, useMemo, useRef } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Color, ShaderMaterial, type Mesh } from "three";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+const hexToNormalizedRGB = (hex: string) => {
+  const normalized = hex.replace("#", "");
+  return [
+    parseInt(normalized.slice(0, 2), 16) / 255,
+    parseInt(normalized.slice(2, 4), 16) / 255,
+    parseInt(normalized.slice(4, 6), 16) / 255,
+  ];
+};
+
+const vertexShader = `
+  varying vec2 vUv;
+  varying vec3 vPosition;
+
+  void main() {
+    vPosition = position;
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = `
+  varying vec2 vUv;
+  varying vec3 vPosition;
+
+  uniform float uTime;
+  uniform vec3 uColor;
+  uniform float uSpeed;
+  uniform float uScale;
+  uniform float uRotation;
+  uniform float uNoiseIntensity;
+
+  const float e = 2.71828182845904523536;
+
+  float noise(vec2 texCoord) {
+    float G = e;
+    vec2 r = (G * sin(G * texCoord));
+    return fract(r.x * r.y * (1.0 + texCoord.x));
+  }
+
+  vec2 rotateUvs(vec2 uv, float angle) {
+    float c = cos(angle);
+    float s = sin(angle);
+    mat2 rot = mat2(c, -s, s, c);
+    return rot * uv;
+  }
+
+  void main() {
+    float rnd = noise(gl_FragCoord.xy);
+    vec2 uv = rotateUvs(vUv * uScale, uRotation);
+    vec2 tex = uv * uScale;
+    float tOffset = uSpeed * uTime;
+
+    tex.y += 0.03 * sin(8.0 * tex.x - tOffset);
+
+    float pattern = 0.6 +
+                    0.4 * sin(5.0 * (tex.x + tex.y +
+                            cos(3.0 * tex.x + 5.0 * tex.y) +
+                            0.02 * tOffset) +
+                            sin(20.0 * (tex.x + tex.y - 0.1 * tOffset)));
+
+    vec4 col = vec4(uColor, 1.0) * vec4(pattern) - rnd / 15.0 * uNoiseIntensity;
+    col.a = 1.0;
+    gl_FragColor = col;
+  }
+`;
+
+type SilkMaterialUniforms = {
+  uSpeed: { value: number };
+  uScale: { value: number };
+  uNoiseIntensity: { value: number };
+  uColor: { value: Color };
+  uRotation: { value: number };
+  uTime: { value: number };
+};
+
+type SilkBackgroundProps = {
+  className?: string;
+  speed?: number;
+  scale?: number;
+  color?: string;
+  noiseIntensity?: number;
+  rotation?: number;
+};
+
+const SilkPlane = forwardRef<Mesh, { uniforms: SilkMaterialUniforms }>(
+  ({ uniforms }, ref) => {
+    const { viewport } = useThree();
+
+    useLayoutEffect(() => {
+      if (ref && typeof ref !== "function" && ref.current) {
+        ref.current.scale.set(viewport.width, viewport.height, 1);
+      }
+    }, [ref, viewport]);
+
+    useFrame((_, delta) => {
+      if (ref && typeof ref !== "function" && ref.current) {
+        const material = ref.current.material as ShaderMaterial;
+        material.uniforms.uTime.value += 0.1 * delta;
+      }
+    });
+
+    return (
+      <mesh ref={ref}>
+        <planeGeometry args={[1, 1, 1, 1]} />
+        <shaderMaterial
+          uniforms={uniforms}
+          vertexShader={vertexShader}
+          fragmentShader={fragmentShader}
+        />
+      </mesh>
+    );
+  }
+);
+SilkPlane.displayName = "SilkPlane";
+
+export const SilkBackground = ({
+  className,
+  speed = 4,
+  scale = 1,
+  color = "#6f7cff",
+  noiseIntensity = 1.2,
+  rotation = 0,
+}: SilkBackgroundProps) => {
+  const meshRef = useRef<Mesh>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const uniforms = useMemo<SilkMaterialUniforms>(
+    () => ({
+      uSpeed: { value: speed },
+      uScale: { value: scale },
+      uNoiseIntensity: { value: noiseIntensity },
+      uColor: { value: new Color(...hexToNormalizedRGB(color)) },
+      uRotation: { value: rotation },
+      uTime: { value: 0 },
+    }),
+    [speed, scale, noiseIntensity, color, rotation]
+  );
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        className={`absolute inset-0 bg-gradient-to-br from-primary/40 via-primary/10 to-transparent ${className ?? ""}`}
+        aria-hidden
+      />
+    );
+  }
+
+  return (
+    <div className={`absolute inset-0 ${className ?? ""}`} aria-hidden>
+      <Canvas dpr={[1, 2]} frameloop="always">
+        <SilkPlane ref={meshRef} uniforms={uniforms} />
+      </Canvas>
+    </div>
+  );
+};

--- a/src/components/reactbits/SplitText.tsx
+++ b/src/components/reactbits/SplitText.tsx
@@ -1,0 +1,61 @@
+import { motion } from "framer-motion";
+import { createElement, useMemo } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+type SplitTextProps = {
+  text: string;
+  as?: keyof JSX.IntrinsicElements;
+  className?: string;
+  stagger?: number;
+  delay?: number;
+};
+
+export const SplitText = ({
+  text,
+  as = "span",
+  className,
+  stagger = 0.05,
+  delay = 0,
+}: SplitTextProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const letters = useMemo(() => text.split(""), [text]);
+  const MotionTag = (motion as Record<string, typeof motion.span>)[as] ?? motion.span;
+
+  if (prefersReducedMotion) {
+    return createElement(as, { className }, text);
+  }
+
+  return (
+    <MotionTag
+      aria-label={text}
+      className={className}
+      initial="hidden"
+      animate="visible"
+      variants={{
+        visible: {
+          transition: {
+            staggerChildren: stagger,
+            delayChildren: delay,
+          },
+        },
+      }}
+    >
+      {letters.map((letter, index) => (
+        <motion.span
+          key={`${letter}-${index}`}
+          className="inline-block"
+          variants={{
+            hidden: { opacity: 0, y: "0.25em" },
+            visible: {
+              opacity: 1,
+              y: "0em",
+              transition: { duration: 0.4, ease: [0.33, 1, 0.68, 1] },
+            },
+          }}
+        >
+          {letter === " " ? "\u00A0" : letter}
+        </motion.span>
+      ))}
+    </MotionTag>
+  );
+};

--- a/src/components/reactbits/SpotlightCard.tsx
+++ b/src/components/reactbits/SpotlightCard.tsx
@@ -1,0 +1,65 @@
+import { ReactNode, useRef, useState } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { cn } from "@/lib/utils";
+
+type SpotlightCardProps = {
+  title: string;
+  description: string;
+  icon?: ReactNode;
+  className?: string;
+};
+
+export const SpotlightCard = ({ title, description, icon, className }: SpotlightCardProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [position, setPosition] = useState({ x: "50%", y: "50%" });
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (prefersReducedMotion) return;
+    const bounds = containerRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    const x = ((event.clientX - bounds.left) / bounds.width) * 100;
+    const y = ((event.clientY - bounds.top) / bounds.height) * 100;
+    setPosition({ x: `${x}%`, y: `${y}%` });
+  };
+
+  const handlePointerLeave = () => {
+    if (prefersReducedMotion) return;
+    setPosition({ x: "50%", y: "50%" });
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+      className={cn(
+        "group relative overflow-hidden rounded-2xl border border-border/60 bg-card/80 p-8 transition-all duration-300",
+        "hover:border-primary/60 hover:shadow-[0_20px_60px_-40px_rgba(103,80,255,0.8)]",
+        className
+      )}
+      style={{
+        ...(prefersReducedMotion
+          ? {}
+          : {
+              backgroundImage: `radial-gradient(circle at ${position.x} ${position.y}, rgba(99,102,241,0.25), transparent 55%)`,
+            }),
+      }}
+    >
+      <div className="relative z-10 space-y-4">
+        {icon && (
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            {icon}
+          </div>
+        )}
+        <h3 className="text-fluid-xl font-semibold text-foreground">{title}</h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+      </div>
+      {!prefersReducedMotion && (
+        <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-primary/5 mix-blend-screen" />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/reactbits/Stepper.tsx
+++ b/src/components/reactbits/Stepper.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+
+type StepItem = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+type StepperProps = {
+  steps: StepItem[];
+  className?: string;
+};
+
+export const Stepper = ({ steps, className }: StepperProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const progress = useMemo(() => (steps.length > 1 ? 100 / (steps.length - 1) : 100), [steps.length]);
+
+  return (
+    <ol className={cn("relative space-y-8", className)}>
+      <div className="absolute left-4 top-0 hidden h-full w-px bg-gradient-to-b from-primary/60 via-primary/20 to-transparent md:block" />
+      {steps.map((step, index) => (
+        <li key={step.id} className="relative flex gap-4">
+          <div className="flex-shrink-0">
+            <div
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-full border border-primary/40 text-sm font-semibold",
+                "bg-primary/10 text-primary",
+              )}
+            >
+              {index + 1}
+            </div>
+          </div>
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-fluid-lg font-semibold text-foreground">{step.title}</h3>
+              <span className="hidden text-xs uppercase tracking-wide text-muted-foreground md:block">
+                {Math.round(progress * index)}%
+              </span>
+            </div>
+            {step.description && (
+              <p className="text-sm text-muted-foreground leading-relaxed">{step.description}</p>
+            )}
+            {!prefersReducedMotion && index < steps.length - 1 && (
+              <div className="relative hidden h-px w-full overflow-hidden md:block">
+                <motion.span
+                  className="absolute inset-0 bg-gradient-to-r from-primary/60 via-primary/40 to-transparent"
+                  initial={{ scaleX: 0 }}
+                  animate={{ scaleX: 1 }}
+                  transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity, repeatType: "reverse" }}
+                  style={{ transformOrigin: "left" }}
+                />
+              </div>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/src/components/reactbits/TextType.tsx
+++ b/src/components/reactbits/TextType.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+type TextTypeProps = {
+  text: string;
+  speed?: number;
+  delay?: number;
+  className?: string;
+};
+
+export const TextType = ({ text, speed = 40, delay = 400, className }: TextTypeProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [displayed, setDisplayed] = useState(prefersReducedMotion ? text : "");
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setDisplayed(text);
+      return;
+    }
+
+    let mounted = true;
+    const characters = Array.from(text);
+    let index = 0;
+
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    const timeout = setTimeout(() => {
+      interval = setInterval(() => {
+        if (!mounted) return;
+        index += 1;
+        setDisplayed(characters.slice(0, index).join(""));
+        if (index >= characters.length) {
+          if (interval) {
+            clearInterval(interval);
+          }
+        }
+      }, speed);
+    }, delay);
+
+    return () => {
+      mounted = false;
+      clearTimeout(timeout);
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [delay, prefersReducedMotion, speed, text]);
+
+  return (
+    <p className={className} aria-live="polite">
+      {displayed}
+      {!prefersReducedMotion && displayed.length < text.length && (
+        <span className="ml-0.5 inline-block w-2 animate-pulse bg-primary/80" aria-hidden />
+      )}
+    </p>
+  );
+};

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+};

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,6 +2,8 @@ import { SectionReveal } from "@/components/SectionReveal";
 import { Button } from "@/components/ui/button";
 import { Instagram, Mail } from "lucide-react";
 import { Link } from "react-router-dom";
+import { TextType } from "@/components/reactbits/TextType";
+import { Stepper } from "@/components/reactbits/Stepper";
 
 const About = () => {
   const timeline = [
@@ -31,16 +33,15 @@ const About = () => {
           <SectionReveal delay={0.1}>
             <div className="space-y-6">
               <h2 className="text-fluid-3xl font-bold">Leonardo Silva</h2>
+              <TextType
+                text="I'm a digital artist and creative developer based in Brazil, specializing in motion design, 3D art, and interactive installations. My work explores the boundaries between the physical and digital, creating immersive experiences that invite viewers to question their perception of reality."
+                className="text-fluid-base text-muted-foreground leading-relaxed"
+                speed={35}
+              />
               <p className="text-fluid-base text-muted-foreground leading-relaxed">
-                I'm a digital artist and creative developer based in Brazil, specializing in 
-                motion design, 3D art, and interactive installations. My work explores the 
-                boundaries between the physical and digital, creating immersive experiences 
-                that invite viewers to question their perception of reality.
-              </p>
-              <p className="text-fluid-base text-muted-foreground leading-relaxed">
-                With a background in computer science and fine arts, I blend technical 
-                expertise with artistic vision to craft unique visual narratives. Each piece 
-                is an investigation into the relationship between form, color, movement, 
+                With a background in computer science and fine arts, I blend technical
+                expertise with artistic vision to craft unique visual narratives. Each piece
+                is an investigation into the relationship between form, color, movement,
                 and emotion in digital space.
               </p>
               <div className="flex flex-wrap gap-4 pt-4">
@@ -85,21 +86,14 @@ const About = () => {
             <h2 className="text-fluid-3xl font-bold mb-8 text-center">
               Exhibitions & <span className="bg-gradient-primary bg-clip-text text-transparent">Timeline</span>
             </h2>
-            <div className="space-y-6">
-              {timeline.map((item, index) => (
-                <div
-                  key={index}
-                  className="flex items-start gap-6 p-6 rounded-xl bg-card border border-border hover:border-primary/50 transition-all"
-                >
-                  <div className="flex-shrink-0 w-20 h-20 rounded-full bg-gradient-primary flex items-center justify-center text-primary-foreground font-bold text-lg">
-                    {item.year}
-                  </div>
-                  <div className="flex-1 pt-3">
-                    <p className="text-fluid-lg font-medium">{item.event}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
+            <Stepper
+              steps={timeline.map((item) => ({
+                id: item.year,
+                title: item.year,
+                description: item.event,
+              }))}
+              className="mx-auto max-w-2xl"
+            />
           </div>
         </SectionReveal>
       </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,6 +6,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { Mail, Instagram, Send } from "lucide-react";
+import { RippleGrid } from "@/components/reactbits/RippleGrid";
+import { GlassIcon } from "@/components/reactbits/GlassIcon";
 
 const Contact = () => {
   const { toast } = useToast();
@@ -53,54 +55,42 @@ const Contact = () => {
           </div>
         </SectionReveal>
 
-        <div className="max-w-4xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-12">
+        <div className="relative max-w-4xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-12 overflow-hidden rounded-3xl border border-border/60 bg-background/80 p-8">
+          <RippleGrid className="pointer-events-none absolute inset-0 opacity-80" color="rgba(99,102,241,0.18)" speed={5} />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-background/90 via-background/60 to-background" />
+
           {/* Contact Info */}
           <SectionReveal delay={0.1}>
-            <div className="space-y-8">
+            <div className="relative space-y-8">
               <div>
                 <h2 className="text-fluid-2xl font-bold mb-6">Let's Connect</h2>
                 <p className="text-muted-foreground leading-relaxed mb-6">
-                  Whether you're interested in collaborating, commissioning work, or just 
-                  want to chat about art and technology, feel free to reach out through 
+                  Whether you're interested in collaborating, commissioning work, or just
+                  want to chat about art and technology, feel free to reach out through
                   the form or my social channels.
                 </p>
               </div>
 
               <div className="space-y-4">
-                <a
+                <GlassIcon
+                  icon={<Mail className="h-6 w-6" />}
+                  title="Email"
+                  description="contact@artleo.com"
                   href="mailto:contact@artleo.com"
-                  className="flex items-center gap-3 p-4 rounded-xl bg-card border border-border hover:border-primary/50 transition-all group"
-                >
-                  <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
-                    <Mail className="w-6 h-6 text-primary" />
-                  </div>
-                  <div>
-                    <p className="font-medium">Email</p>
-                    <p className="text-sm text-muted-foreground">contact@artleo.com</p>
-                  </div>
-                </a>
-
-                <a
+                />
+                <GlassIcon
+                  icon={<Instagram className="h-6 w-6" />}
+                  title="Instagram"
+                  description="@leonardossil"
                   href="https://www.instagram.com/leonardossil/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-3 p-4 rounded-xl bg-card border border-border hover:border-primary/50 transition-all group"
-                >
-                  <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
-                    <Instagram className="w-6 h-6 text-primary" />
-                  </div>
-                  <div>
-                    <p className="font-medium">Instagram</p>
-                    <p className="text-sm text-muted-foreground">@leonardossil</p>
-                  </div>
-                </a>
+                />
               </div>
             </div>
           </SectionReveal>
 
           {/* Contact Form */}
           <SectionReveal delay={0.2}>
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="relative space-y-6">
               <div className="space-y-2">
                 <Label htmlFor="name">Name</Label>
                 <Input

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,21 +1,21 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Hero3D } from "@/components/Hero3D";
 import { SectionReveal } from "@/components/SectionReveal";
 import { ArrowRight, Sparkles, Palette, Eye } from "lucide-react";
 import { motion } from "framer-motion";
+import { SilkBackground } from "@/components/reactbits/SilkBackground";
+import { SplitText } from "@/components/reactbits/SplitText";
+import { SpotlightCard } from "@/components/reactbits/SpotlightCard";
 
 const Home = () => {
   return (
     <div className="min-h-screen">
       {/* Hero Section */}
       <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
-        {/* 3D Background */}
-        <Hero3D />
-        
-        {/* Gradient Overlay */}
-        <div className="absolute inset-0 bg-gradient-mesh" />
-        
+        {/* Silk Background with fallback */}
+        <SilkBackground className="opacity-90" color="#6f7cff" speed={4.5} noiseIntensity={1.1} rotation={0.3} />
+        <div className="absolute inset-0 bg-gradient-to-b from-background/40 via-background/60 to-background" />
+
         {/* Content */}
         <div className="relative z-10 container mx-auto px-4 text-center">
           <motion.div
@@ -35,12 +35,20 @@ const Home = () => {
               </span>
             </motion.div>
 
-            <h1 className="text-fluid-5xl font-bold mb-6 leading-tight">
-              <span className="bg-gradient-primary bg-clip-text text-transparent">
-                Leonardo Silva
-              </span>
-              <br />
-              <span className="text-foreground">Crafting Visual Stories</span>
+            <h1 className="text-fluid-5xl font-bold mb-6 leading-tight space-y-2">
+              <SplitText
+                as="span"
+                text="Leonardo Silva"
+                className="block bg-gradient-primary bg-clip-text text-transparent"
+                stagger={0.06}
+              />
+              <SplitText
+                as="span"
+                text="Crafting Visual Stories"
+                className="block text-foreground"
+                stagger={0.05}
+                delay={0.4}
+              />
             </h1>
 
             <p className="text-fluid-lg text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
@@ -97,17 +105,24 @@ const Home = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {[
-              { icon: Palette, title: "Motion Design", desc: "Dynamic visual narratives" },
-              { icon: Eye, title: "3D Art", desc: "Immersive spatial experiences" },
-              { icon: Sparkles, title: "Interactive", desc: "Engaging digital installations" },
+              {
+                icon: <Palette className="h-7 w-7" />,
+                title: "Motion Design",
+                desc: "Dynamic visual narratives",
+              },
+              {
+                icon: <Eye className="h-7 w-7" />,
+                title: "3D Art",
+                desc: "Immersive spatial experiences",
+              },
+              {
+                icon: <Sparkles className="h-7 w-7" />,
+                title: "Interactive",
+                desc: "Engaging digital installations",
+              },
             ].map((item, index) => (
-              <SectionReveal key={index} delay={index * 0.1}>
-                <div className="group relative p-8 rounded-2xl bg-card border border-border hover:border-primary/50 transition-all duration-300 hover:shadow-card">
-                  <div className="absolute inset-0 bg-gradient-primary opacity-0 group-hover:opacity-5 rounded-2xl transition-opacity" />
-                  <item.icon className="w-12 h-12 text-primary mb-4" />
-                  <h3 className="text-fluid-xl font-bold mb-2">{item.title}</h3>
-                  <p className="text-muted-foreground">{item.desc}</p>
-                </div>
+              <SectionReveal key={item.title} delay={index * 0.1}>
+                <SpotlightCard title={item.title} description={item.desc} icon={item.icon} />
               </SectionReveal>
             ))}
           </div>

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -5,6 +5,8 @@ import { SectionReveal } from "@/components/SectionReveal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, Filter } from "lucide-react";
+import { PixelCard } from "@/components/reactbits/PixelCard";
+import { RollingGallery } from "@/components/reactbits/RollingGallery";
 
 // Mock data - will be replaced with Lovable Cloud data
 const artworks = [
@@ -85,6 +87,19 @@ const Portfolio = () => {
           </div>
         </SectionReveal>
 
+        <SectionReveal delay={0.05}>
+          <RollingGallery
+            items={artworks.slice(0, 4).map((artwork) => ({
+              id: artwork.slug,
+              image: artwork.coverUrl,
+              title: artwork.title,
+              subtitle: artwork.category,
+            }))}
+            className="mb-16"
+            speed={28}
+          />
+        </SectionReveal>
+
         {/* Filters */}
         <SectionReveal delay={0.1}>
           <div className="mb-12 space-y-6">
@@ -127,37 +142,18 @@ const Portfolio = () => {
             <motion.div
               key={artwork.id}
               layout
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.9 }}
-              transition={{ duration: 0.3, delay: index * 0.05 }}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 12 }}
+              transition={{ duration: 0.4, delay: index * 0.05 }}
             >
               <Link to={`/art/${artwork.slug}`} className="group block">
-                <div className="relative overflow-hidden rounded-2xl bg-card border border-border hover:border-primary/50 transition-all duration-300 hover:shadow-card">
-                  {/* Image */}
-                  <div className="aspect-[4/3] overflow-hidden">
-                    <img
-                      src={artwork.coverUrl}
-                      alt={artwork.title}
-                      className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
-                      loading="lazy"
-                    />
-                  </div>
-
-                  {/* Overlay */}
-                  <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-
-                  {/* Content */}
-                  <div className="absolute bottom-0 left-0 right-0 p-6 translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
-                    <span className="inline-block px-3 py-1 text-xs font-medium rounded-full bg-primary/20 text-primary border border-primary/30 mb-2">
-                      {artwork.category}
-                    </span>
-                    <h3 className="text-fluid-xl font-bold text-foreground mb-1">
-                      {artwork.title}
-                    </h3>
-                    <p className="text-sm text-muted-foreground">{artwork.year}</p>
-                  </div>
-                </div>
+                <PixelCard
+                  image={artwork.coverUrl}
+                  title={artwork.title}
+                  subtitle={artwork.category}
+                  footer={<span>{artwork.year}</span>}
+                />
               </Link>
             </motion.div>
           ))}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -113,6 +113,10 @@ export default {
           "0%": { clipPath: "inset(0 100% 0 0)" },
           "100%": { clipPath: "inset(0 0 0 0)" },
         },
+        "scroll-vertical": {
+          "0%": { transform: "translateY(0)" },
+          "100%": { transform: "translateY(-50%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.3s ease-out",
@@ -123,6 +127,7 @@ export default {
         "glow-pulse": "glow-pulse 3s ease-in-out infinite",
         float: "float 6s ease-in-out infinite",
         "reveal-text": "reveal-text 1.2s cubic-bezier(0.77, 0, 0.175, 1)",
+        "scroll-vertical": "scroll-vertical 12s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace the home hero with the React Bits silk background, split text title, and spotlight service cards while respecting reduced-motion fallbacks
- revamp portfolio, about, and contact pages with pixel cards, rolling gallery, typewriter bio, stepper timeline, ripple grid, and glass icons components limited to 2–3 per view
- refresh navigation with a gooey desktop bar and infinite mobile menu backed by a shared reduced-motion hook and supporting utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd227200ec8322a7f060535f910d2f