### PR TITLE
Add depth surface tokens and utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/index.css
+++ b/src/index.css
@@ -8,14 +8,14 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
+    --background: 0 0% 98%;
+    --foreground: 240 10% 3.9%;
 
-    --card: 240 10% 5%;
-    --card-foreground: 0 0% 98%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
 
-    --popover: 240 10% 4.5%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
 
     --primary: 263 70% 65%;
     --primary-foreground: 0 0% 100%;
@@ -25,8 +25,8 @@ All colors MUST be HSL.
     --secondary-foreground: 0 0% 100%;
     --secondary-glow: 217 91% 70%;
 
-    --muted: 240 5% 15%;
-    --muted-foreground: 240 5% 64.9%;
+    --muted: 240 6% 90%;
+    --muted-foreground: 240 5% 40%;
 
     --accent: 263 70% 65%;
     --accent-foreground: 0 0% 100%;
@@ -34,8 +34,8 @@ All colors MUST be HSL.
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 240 5% 20%;
-    --input: 240 5% 20%;
+    --border: 240 6% 85%;
+    --input: 240 6% 85%;
     --ring: 263 70% 65%;
 
     --radius: 1rem;
@@ -47,14 +47,89 @@ All colors MUST be HSL.
                      radial-gradient(at 97% 21%, hsl(217 91% 60% / 0.12) 0px, transparent 50%),
                      radial-gradient(at 52% 99%, hsl(263 70% 65% / 0.09) 0px, transparent 50%);
 
-    /* Shadows */
+    /* Depth surfaces */
+    --surface-0: 0 0% 98%;
+    --surface-1: 0 0% 100%;
+    --surface-2: 0 0% 100%;
+    --surface-3: 0 0% 100%;
+
+    /* Shadow palette */
+    --shadow-ambient: 220 40% 2%;
+    --shadow-edge: 220 40% 10%;
+    --shadow-hi: 0 0% 100%;
+
+    /* Shadow presets */
+    --shadow-depth-sm:
+      inset 0 1px 0 hsl(var(--shadow-hi) / 0.55),
+      0 1px 1px hsl(var(--shadow-ambient) / 0.1),
+      0 2px 6px hsl(var(--shadow-ambient) / 0.1);
+    --shadow-depth:
+      inset 0 1px 0 hsl(var(--shadow-hi) / 0.5),
+      0 1px 2px hsl(var(--shadow-edge) / 0.08),
+      0 8px 24px hsl(var(--shadow-ambient) / 0.18);
+    --shadow-depth-lg:
+      inset 0 1px 0 hsl(var(--shadow-hi) / 0.45),
+      0 2px 6px hsl(var(--shadow-edge) / 0.06),
+      0 24px 48px hsl(var(--shadow-ambient) / 0.22);
+    --shadow-inset-depth:
+      inset 0 1px 0 hsl(var(--shadow-hi) / 0.35),
+      inset 0 -1px 0 hsl(var(--shadow-ambient) / 0.35);
+
+    /* Legacy shadows */
     --shadow-glow: 0 0 40px hsl(263 70% 65% / 0.3);
-    --shadow-depth: 0 20px 40px -15px hsl(240 10% 3.9% / 0.8);
     --shadow-card: 0 10px 30px -10px hsl(240 10% 0% / 0.5);
+
+    /* Highlight overlay */
+    --top-glow: linear-gradient(180deg, hsl(var(--shadow-hi) / 0.06), transparent 20%);
 
     /* Transitions */
     --transition-smooth: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-spring: all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .dark {
+    color-scheme: dark;
+
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+
+    --card: 240 10% 5%;
+    --card-foreground: 0 0% 98%;
+
+    --popover: 240 10% 4.5%;
+    --popover-foreground: 0 0% 98%;
+
+    --muted: 240 5% 15%;
+    --muted-foreground: 240 5% 64.9%;
+
+    --border: 240 5% 20%;
+    --input: 240 5% 20%;
+
+    --surface-0: 240 10% 5%;
+    --surface-1: 240 10% 7%;
+    --surface-2: 240 10% 9%;
+    --surface-3: 240 10% 12%;
+
+    --shadow-ambient: 240 60% 3%;
+    --shadow-edge: 240 40% 20%;
+    --shadow-hi: 0 0% 100%;
+  }
+
+  .bg-surface-0 { background-color: hsl(var(--surface-0)); }
+  .bg-surface-1 { background-color: hsl(var(--surface-1)); }
+  .bg-surface-2 { background-color: hsl(var(--surface-2)); }
+  .bg-surface-3 { background-color: hsl(var(--surface-3)); }
+
+  .shadow-depth-sm { box-shadow: var(--shadow-depth-sm); }
+  .shadow-depth    { box-shadow: var(--shadow-depth); }
+  .shadow-depth-lg { box-shadow: var(--shadow-depth-lg); }
+  .shadow-inset    { box-shadow: var(--shadow-inset-depth); }
+
+  .top-glow { background-image: var(--top-glow); }
+
+  .h1-fluid {
+    font-size: clamp(1.875rem, 4vw + 1rem, 3.5rem);
+    line-height: 1.1;
   }
 }
 
@@ -64,6 +139,8 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground overflow-x-hidden;
+    background-color: hsl(var(--surface-0));
+    color: hsl(var(--foreground));
+    @apply overflow-x-hidden;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,12 @@ export default {
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        surface: {
+          0: "hsl(var(--surface-0))",
+          1: "hsl(var(--surface-1))",
+          2: "hsl(var(--surface-2))",
+          3: "hsl(var(--surface-3))",
+        },
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
@@ -58,10 +64,14 @@ export default {
         "gradient-primary": "var(--gradient-primary)",
         "gradient-glow": "var(--gradient-glow)",
         "gradient-mesh": "var(--gradient-mesh)",
+        topGlow: "var(--top-glow)",
       },
       boxShadow: {
         glow: "var(--shadow-glow)",
+        depthSm: "var(--shadow-depth-sm)",
         depth: "var(--shadow-depth)",
+        depthLg: "var(--shadow-depth-lg)",
+        insetDepth: "var(--shadow-inset-depth)",
         card: "var(--shadow-card)",
       },
       transitionTimingFunction: {


### PR DESCRIPTION
## Summary
- add layered surface and shadow tokens plus utilities in the base stylesheet, including a fluid display helper
- expose the new surface colors and depth shadows through the Tailwind theme and default the document to dark mode for consistency
- align the global body background with the layered surface system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e23adf25508322a8e39674559ec3cb