### PR TITLE
Refine navigation surfaces and tabs styling

### DIFF
--- a/src/components/reactbits/FlowingMenu.tsx
+++ b/src/components/reactbits/FlowingMenu.tsx
@@ -100,15 +100,17 @@ const MenuItem: React.FC<MenuItemProps> = ({ href, label, accent, isActive, redu
     <div
       ref={itemRef}
       className={cn(
-        "group relative flex-1 overflow-hidden border-t border-border/40 text-center first:border-t-0",
-        isActive ? "bg-white/5" : undefined,
+        "group relative flex-1 overflow-hidden bg-surface-0 text-center shadow-inset transition-colors",
+        isActive
+          ? "bg-surface-2 shadow-[0_-8px_24px_rgba(99,102,241,0.35)] before:pointer-events-none before:absolute before:inset-x-6 before:top-0 before:h-1 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.45),transparent)] before:content-['']"
+          : undefined,
       )}
     >
       <Link
         to={href}
         className={cn(
-          "flex h-full min-h-[64px] w-full items-center justify-center px-6 py-4 text-lg font-semibold uppercase transition-colors", 
-          isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
+          "flex h-full min-h-[64px] w-full items-center justify-center px-6 py-4 text-lg font-semibold uppercase transition-colors",
+          isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground",
         )}
         onMouseEnter={handleEnter}
         onMouseLeave={handleLeave}

--- a/src/components/reactbits/GooeyNav.tsx
+++ b/src/components/reactbits/GooeyNav.tsx
@@ -38,7 +38,10 @@ export const GooeyNav = () => {
   return (
     <header className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6 sm:pt-6">
       <nav
-        className="mx-auto flex w-full max-w-5xl items-center justify-between gap-2 rounded-full border border-border/70 bg-surface-0/70 px-4 py-2 backdrop-blur-xl motion-reduce:transition-none min-h-[3.5rem]"
+        className="relative mx-auto flex w-full max-w-5xl items-center justify-between gap-2 rounded-full bg-surface-1 px-4 py-2 shadow-lg backdrop-blur-xl motion-reduce:transition-none min-h-[3.5rem]"
+        style={{
+          background: "linear-gradient(180deg, hsl(var(--surface-1) / 0.98), hsl(var(--surface-1) / 0.85))",
+        }}
       >
         <Link
           to="/"

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-full bg-surface-0 p-1 text-muted-foreground shadow-inset",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-surface-0 transition-all data-[state=active]:bg-surface-1 data-[state=active]:text-foreground data-[state=active]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground ring-offset-surface-0 transition-all hover:text-foreground data-[state=active]:bg-surface-2 data-[state=active]:text-foreground data-[state=active]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Refresh the Gooey navigation bar container with the new surface tone, subtle gradient, and elevated shadow.
- Update FlowingMenu items to use inset surfaces with active highlights for better depth cues.
- Align Tabs primitives with the latest surface tokens, including elevated active triggers and inset list styling.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e240b543f08322bbb42f448d5b6cf0