### PR TITLE
Refine surface hierarchy and card shadows

### DIFF
--- a/src/components/reactbits/PixelCard.tsx
+++ b/src/components/reactbits/PixelCard.tsx
@@ -24,8 +24,8 @@ export const PixelCard = ({
   return (
     <div
       className={cn(
-        "group relative block overflow-hidden rounded-2xl border border-border/80 bg-surface-2/70 backdrop-blur-xl",
-        "transition-all duration-500 hover:-translate-y-1 hover:border-primary/60 hover:shadow-[0_25px_45px_-20px_rgba(76,0,130,0.35)]",
+        "group relative block overflow-hidden rounded-2xl bg-surface-1 shadow-inset backdrop-blur-xl",
+        "transition-all duration-500 hover:-translate-y-2 hover:shadow-lg",
         className,
       )}
     >

--- a/src/components/reactbits/SpotlightCard.tsx
+++ b/src/components/reactbits/SpotlightCard.tsx
@@ -36,8 +36,11 @@ export const SpotlightCard = ({
         mouseY.set(0);
       }}
       className={cn(
-        "group relative overflow-hidden rounded-2xl border border-border/70 bg-surface-2/80 p-8 backdrop-blur-xl transition-shadow",
-        "shadow-[0_25px_45px_-20px_rgba(76,0,130,0.35)]",
+        "group relative overflow-hidden rounded-2xl bg-surface-1 p-8 shadow-sm backdrop-blur-xl transition-all duration-300",
+        "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-1/2 before:rounded-t-2xl",
+        "before:bg-gradient-to-b before:from-white/20 before:via-white/10 before:to-transparent before:opacity-40 before:transition-opacity before:duration-300 before:content-[''] before:mix-blend-screen",
+        "group-hover:before:opacity-80",
+        "hover:shadow-lg",
         className,
       )}
     >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -15,8 +15,8 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:shadow-glow",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-gradient-primary text-primary-foreground hover:shadow-glow hover:scale-105 transition-all duration-300",
-        glass: "bg-surface-1/50 backdrop-blur-md border border-border/50 text-foreground hover:bg-surface-1/70 hover:border-border",
+        hero: "bg-gradient-primary text-primary-foreground shadow-lg hover:shadow-glow hover:scale-105 transition-all duration-300",
+        glass: "bg-surface-1/50 backdrop-blur-md border border-border/50 text-foreground shadow-sm hover:bg-surface-1/70 hover:border-border hover:shadow-lg",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,14 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-surface-1 text-card-foreground shadow-sm", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-border/60 bg-surface-2 text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
 ));
 Card.displayName = "Card";
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@ All colors MUST be HSL.
     --surface-0: 240 12% 6%;
     --surface-1: 240 14% 10%;
     --surface-2: 240 18% 14%;
+    --surface-3: 240 22% 20%;
 
     --shadow-sm: 0 8px 24px -12px hsl(240 14% 10% / 0.55);
     --shadow-lg: 0 30px 70px -30px hsl(240 18% 14% / 0.65);
@@ -69,6 +70,7 @@ All colors MUST be HSL.
     --surface-0: 240 22% 10%;
     --surface-1: 240 24% 16%;
     --surface-2: 240 26% 22%;
+    --surface-3: 240 28% 28%;
 
     --shadow-sm: 0 10px 28px -16px hsl(240 24% 14% / 0.55);
     --shadow-lg: 0 40px 80px -32px hsl(240 26% 20% / 0.7);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -101,7 +101,7 @@ const Home = () => {
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
             {FEATURED_DISCIPLINES.map((item, index) => (
               <SectionReveal key={index} delay={index * 0.1}>
-                <SpotlightCard className="p-6 sm:p-8">
+                <SpotlightCard className="bg-surface-3/90 p-6 sm:p-8">
                   <div className="flex flex-col gap-3 text-left sm:gap-4">
                     <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                       <item.icon className="h-7 w-7" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,6 +57,7 @@ export default {
           0: "hsl(var(--surface-0))",
           1: "hsl(var(--surface-1))",
           2: "hsl(var(--surface-2))",
+          3: "hsl(var(--surface-3))",
         },
       },
       backgroundImage: {


### PR DESCRIPTION
## Summary
- introduce a new surface-3 token to expand the surface palette and update Tailwind to expose it
- refresh SpotlightCard and PixelCard styling with surface-1 bases, inset illumination, and hover depth cues
- align generic Card, hero/glass buttons, and home spotlight tiles with the new surface hierarchy and shadow tokens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e241a982a083228186eda276a1716f