### PR TITLE
Refine contact page depth styling

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,14 +4,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "relative inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+        default:
+          "bg-primary text-primary-foreground shadow-lg shadow-primary/40 hover:bg-primary/85",
+        secondary: "bg-surface-2 text-foreground hover:bg-surface-2/80",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-lg shadow-destructive/40 hover:bg-destructive/90",
+        outline:
+          "bg-surface-0/40 text-foreground shadow-none before:absolute before:inset-x-0 before:top-0 before:h-px before:rounded-t-full before:bg-white/20 before:content-['']",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -15,8 +15,8 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:shadow-glow",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-gradient-primary text-primary-foreground shadow-lg hover:shadow-glow hover:scale-105 transition-all duration-300",
-        glass: "bg-surface-1/50 backdrop-blur-md border border-border/50 text-foreground shadow-sm hover:bg-surface-1/70 hover:border-border hover:shadow-lg",
+        hero: "bg-gradient-primary text-primary-foreground shadow-sm transition-all duration-300 hover:shadow-lg focus-visible:shadow-lg hover:scale-105",
+        glass: "bg-surface-1/50 backdrop-blur-md border border-border/50 text-foreground shadow-sm transition-shadow hover:bg-surface-1/70 hover:border-border hover:shadow-lg focus-visible:shadow-lg",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-surface-1 px-3 py-2 text-base ring-offset-surface-0 shadow-inset file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex h-10 w-full rounded-md border border-input bg-surface-2 px-3 py-2 text-base ring-offset-surface-0 shadow-inset transition-shadow file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-white/50 focus-visible:shadow-sm focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -9,11 +9,14 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-surface-0 shadow-inset",
+      className,
+    )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="relative h-full w-full flex-1 rounded-full bg-primary shadow-sm transition-all after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-white/40 after:content-['']"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,8 +4,10 @@ import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    <div className="relative w-full overflow-hidden rounded-xl bg-surface-0 shadow-inset">
+      <div className="overflow-auto">
+        <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+      </div>
     </div>
   ),
 );
@@ -34,7 +36,10 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
-      className={cn("border-b transition-colors data-[state=selected]:bg-muted hover:bg-muted/50", className)}
+      className={cn(
+        "transition-colors data-[state=selected]:bg-surface-1/80 hover:bg-surface-1",
+        className,
+      )}
       {...props}
     />
   ),

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-surface-1 px-3 py-2 text-sm ring-offset-surface-0 shadow-inset placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-surface-2 px-3 py-2 text-sm ring-offset-surface-0 shadow-inset transition-shadow placeholder:text-muted-foreground focus-visible:border-white/50 focus-visible:shadow-sm focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -74,104 +74,104 @@ const Contact = () => {
           </div>
         </SectionReveal>
 
-        <div className="relative mx-auto max-w-4xl overflow-hidden rounded-[2rem] border border-border/60 bg-surface-1/60 p-6 sm:rounded-[2.5rem] sm:p-10 shadow-lg">
+        <div className="relative mx-auto max-w-4xl overflow-hidden rounded-[2rem] border border-border/60 bg-surface-0 p-2 sm:rounded-[2.5rem] sm:p-4 shadow-inset">
           <RippleGridBackground />
-          <div className="relative z-10 grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-12">
-            {/* Contact Info */}
-            <div className="col-span-1">
-              <SectionReveal delay={0.1}>
-                <div className="space-y-8">
-                  <div>
-                    <h2 className="mb-6 text-[clamp(1.5rem,5.5vw,2.5rem)] font-bold leading-tight">Let's Connect</h2>
-                    <p className="mb-6 text-[clamp(1rem,3.3vw,1.1rem)] text-muted-foreground leading-relaxed">
-                      Whether you're interested in collaborating, commissioning work, or just
-                      want to chat about art and technology, feel free to reach out through
-                      the form or my social channels.
-                    </p>
-                  </div>
+          <div className="relative z-10 rounded-[1.75rem] bg-surface-1 p-6 shadow-lg sm:rounded-[2.25rem] sm:p-10">
+            <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-12">
+              {/* Contact Info */}
+              <div className="col-span-1">
+                <SectionReveal delay={0.1}>
+                  <div className="space-y-8">
+                    <div>
+                      <h2 className="mb-6 text-[clamp(1.5rem,5.5vw,2.5rem)] font-bold leading-tight">Let's Connect</h2>
+                      <p className="mb-6 text-[clamp(1rem,3.3vw,1.1rem)] text-muted-foreground leading-relaxed">
+                        Whether you're interested in collaborating, commissioning work, or just
+                        want to chat about art and technology, feel free to reach out through
+                        the form or my social channels.
+                      </p>
+                    </div>
 
-                  <div className="space-y-4">
-                    <GlassIcon
-                      icon={<Mail className="h-6 w-6" />}
-                      title="Email"
-                      description="contact@artleo.com"
-                      href="mailto:contact@artleo.com"
-                    />
-                    <GlassIcon
-                      icon={<Instagram className="h-6 w-6" />}
-                      title="Instagram"
-                      description="@leonardossil"
-                      href="https://www.instagram.com/leonardossil/"
-                    />
+                    <div className="space-y-4">
+                      <GlassIcon
+                        icon={<Mail className="h-6 w-6" />}
+                        title="Email"
+                        description="contact@artleo.com"
+                        href="mailto:contact@artleo.com"
+                      />
+                      <GlassIcon
+                        icon={<Instagram className="h-6 w-6" />}
+                        title="Instagram"
+                        description="@leonardossil"
+                        href="https://www.instagram.com/leonardossil/"
+                      />
+                    </div>
                   </div>
-                </div>
-              </SectionReveal>
-            </div>
+                </SectionReveal>
+              </div>
 
-            {/* Contact Form */}
-            <div className="col-span-1">
-              <SectionReveal delay={0.2}>
-                <form onSubmit={handleSubmit} className="space-y-6">
-                  <div className="space-y-2">
-                    <Label htmlFor="name">Name</Label>
-                    <Input
-                      id="name"
-                      name="name"
-                      type="text"
-                      required
-                      value={formData.name}
-                      onChange={handleChange}
-                      placeholder="Your name"
-                      className="border-border bg-surface-1 shadow-inset"
-                    />
-                  </div>
+              {/* Contact Form */}
+              <div className="col-span-1">
+                <SectionReveal delay={0.2}>
+                  <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="name">Name</Label>
+                      <Input
+                        id="name"
+                        name="name"
+                        type="text"
+                        required
+                        value={formData.name}
+                        onChange={handleChange}
+                        placeholder="Your name"
+                      />
+                    </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                      id="email"
-                      name="email"
-                      type="email"
-                      required
-                      value={formData.email}
-                      onChange={handleChange}
-                      placeholder="your.email@example.com"
-                      className="border-border bg-surface-1 shadow-inset"
-                    />
-                  </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="email">Email</Label>
+                      <Input
+                        id="email"
+                        name="email"
+                        type="email"
+                        required
+                        value={formData.email}
+                        onChange={handleChange}
+                        placeholder="your.email@example.com"
+                      />
+                    </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="message">Message</Label>
-                    <Textarea
-                      id="message"
-                      name="message"
-                      required
-                      value={formData.message}
-                      onChange={handleChange}
-                      placeholder="Tell me about your project or inquiry..."
-                      rows={6}
-                      className="border-border bg-surface-1 shadow-inset resize-none"
-                    />
-                  </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="message">Message</Label>
+                      <Textarea
+                        id="message"
+                        name="message"
+                        required
+                        value={formData.message}
+                        onChange={handleChange}
+                        placeholder="Tell me about your project or inquiry..."
+                        rows={6}
+                        className="resize-none"
+                      />
+                    </div>
 
-                  <Button
-                    type="submit"
-                    variant="hero"
-                    size="lg"
-                    className="w-full motion-reduce:transition-none"
-                    disabled={isPending}
-                  >
-                    {isPending ? (
-                      "Sending..."
-                    ) : (
-                      <>
-                        Send Message
-                        <Send className="w-5 h-5 ml-2" />
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </SectionReveal>
+                    <Button
+                      type="submit"
+                      variant="hero"
+                      size="lg"
+                      className="w-full motion-reduce:transition-none"
+                      disabled={isPending}
+                    >
+                      {isPending ? (
+                        "Sending..."
+                      ) : (
+                        <>
+                          Send Message
+                          <Send className="w-5 h-5 ml-2" />
+                        </>
+                      )}
+                    </Button>
+                  </form>
+                </SectionReveal>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Reworked the Contact card to add a recessed surface wrapper and a raised inner panel for the form layout
- Updated shared input and textarea components to use the new surface tokens and focus shadows for depth cues
- Tuned hero and glass button variants so shadow-lg is applied on hover/focus to match the refreshed lighting model

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e243c6a1048322b479bee67b8e000b