### PR TITLE
Refine shadows and surfaces on core UI primitives

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,14 +4,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "relative inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+        default:
+          "bg-primary text-primary-foreground shadow-lg shadow-primary/40 hover:bg-primary/85",
+        secondary: "bg-surface-2 text-foreground hover:bg-surface-2/80",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-lg shadow-destructive/40 hover:bg-destructive/90",
+        outline:
+          "bg-surface-0/40 text-foreground shadow-none before:absolute before:inset-x-0 before:top-0 before:h-px before:rounded-t-full before:bg-white/20 before:content-['']",
       },
     },
     defaultVariants: {

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -9,11 +9,14 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-surface-0 shadow-inset",
+      className,
+    )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="relative h-full w-full flex-1 rounded-full bg-primary shadow-sm transition-all after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-white/40 after:content-['']"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,8 +4,10 @@ import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    <div className="relative w-full overflow-hidden rounded-xl bg-surface-0 shadow-inset">
+      <div className="overflow-auto">
+        <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+      </div>
     </div>
   ),
 );
@@ -34,7 +36,10 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
-      className={cn("border-b transition-colors data-[state=selected]:bg-muted hover:bg-muted/50", className)}
+      className={cn(
+        "transition-colors data-[state=selected]:bg-surface-1/80 hover:bg-surface-1",
+        className,
+      )}
       {...props}
     />
   ),


### PR DESCRIPTION
## Summary
- wrap table content with surface and inset shadow styling and update row hover state
- refresh progress track and indicator to use surface tokens, inset track, and subtle highlight
- restyle badges around shadowed surfaces and add top highlight for outline variant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e245e0fde88322bd79bb27d0d30f32