### PR TITLE
Make Liquid Ether background global

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 import { Navigation } from "./components/Navigation";
 import { ScrollToTop } from "./components/ScrollToTop";
+import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
 import Home from "./pages/Home";
 import Portfolio from "./pages/Portfolio";
 import ArtworkDetail from "./pages/ArtworkDetail";
@@ -24,16 +25,28 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <ScrollToTop />
-          <Navigation />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/portfolio" element={<Portfolio />} />
-            <Route path="/art/:slug" element={<ArtworkDetail />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-foreground">
+            <div className="pointer-events-none fixed inset-0 -z-10">
+              {/*
+                The Liquid Ether background lives here so every public route inherits it.
+                To disable it for a specific page in the future, read `useLocation()` and
+                conditionally render this block based on the current pathname.
+              */}
+              <LiquidEtherBackground />
+            </div>
+            <Navigation />
+            <main className="relative z-0 flex-1">
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/portfolio" element={<Portfolio />} />
+                <Route path="/art/:slug" element={<ArtworkDetail />} />
+                <Route path="/about" element={<About />} />
+                <Route path="/contact" element={<Contact />} />
+                <Route path="/auth" element={<Auth />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </main>
+          </div>
         </BrowserRouter>
       </TooltipProvider>
     </AuthProvider>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,6 @@ import { Button } from "@/components/ui/button";
 import { SectionReveal } from "@/components/SectionReveal";
 import { ArrowRight, Sparkles, Palette, Eye } from "lucide-react";
 import { motion } from "framer-motion";
-import { SilkBackground } from "@/components/reactbits/SilkBackground";
-import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
 import { SplitText } from "@/components/reactbits/SplitText";
 import { SpotlightCard } from "@/components/reactbits/SpotlightCard";
 
@@ -19,8 +17,6 @@ const Home = () => {
     <div className="min-h-screen overflow-x-hidden">
       {/* Hero Section */}
       <section className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 sm:px-6">
-        {/* <SilkBackground /> */}
-        <LiquidEtherBackground />
 
         {/* Content */}
         <div className="relative z-10 mx-auto w-full max-w-4xl text-center">


### PR DESCRIPTION
## Summary
- mount the Liquid Ether background in the app shell so every public route inherits it
- delegate pointer listeners to the window to keep the animation interactive beneath page content
- remove the page-level Liquid Ether hero instance now that the effect is global

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27ab9be708322abcdd0644eb87432