### PR TITLE
feat: apply liquid ether background globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
-import { Navigation } from "./components/Navigation";
 import { ScrollToTop } from "./components/ScrollToTop";
+import AppLayout from "./components/layouts/AppLayout";
 import Home from "./pages/Home";
 import Portfolio from "./pages/Portfolio";
 import ArtworkDetail from "./pages/ArtworkDetail";
@@ -24,15 +24,16 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <ScrollToTop />
-          <Navigation />
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/portfolio" element={<Portfolio />} />
-            <Route path="/art/:slug" element={<ArtworkDetail />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="*" element={<NotFound />} />
+            <Route element={<AppLayout />}>
+              <Route index element={<Home />} />
+              <Route path="portfolio" element={<Portfolio />} />
+              <Route path="art/:slug" element={<ArtworkDetail />} />
+              <Route path="about" element={<About />} />
+              <Route path="contact" element={<Contact />} />
+              <Route path="auth" element={<Auth />} />
+              <Route path="*" element={<NotFound />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </TooltipProvider>

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -1,0 +1,32 @@
+import { Outlet } from "react-router-dom";
+import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
+import { Navigation } from "@/components/Navigation";
+
+type AppLayoutProps = {
+  /**
+   * Para desativar o efeito Liquid Ether em uma rota específica no futuro,
+   * basta renderizar <AppLayout enableLiquidEther={false}> no registro da rota desejada.
+   */
+  enableLiquidEther?: boolean;
+};
+
+const AppLayout = ({ enableLiquidEther = true }: AppLayoutProps) => {
+  return (
+    <div className="relative min-h-screen bg-[#04060c] text-foreground">
+      {enableLiquidEther && (
+        <div className="pointer-events-none fixed inset-0 -z-20">
+          <LiquidEtherBackground />
+        </div>
+      )}
+
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <Navigation />
+        <main className="flex-1">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/components/reactbits/LiquidEtherBackground.tsx
+++ b/src/components/reactbits/LiquidEtherBackground.tsx
@@ -12,7 +12,7 @@ const LiquidEtherBackground = () => {
   const palette = useMemo(() => ['#5227FF', '#FF9FFC', '#B19EEF'], []);
 
   return (
-    <div className="absolute inset-0" role="presentation" aria-hidden>
+    <div className="absolute inset-0 pointer-events-none" role="presentation" aria-hidden>
       {reduceMotion ? (
         <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-[#1a1033] via-[#0a0d1f] to-[#06121f]">
           <div
@@ -40,6 +40,7 @@ const LiquidEtherBackground = () => {
           takeoverDuration={0.25}
           autoResumeDelay={3000}
           autoRampDuration={0.6}
+          useGlobalPointerEvents
         />
       )}
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,6 @@ import { Button } from "@/components/ui/button";
 import { SectionReveal } from "@/components/SectionReveal";
 import { ArrowRight, Sparkles, Palette, Eye } from "lucide-react";
 import { motion } from "framer-motion";
-import { SilkBackground } from "@/components/reactbits/SilkBackground";
-import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
 import { SplitText } from "@/components/reactbits/SplitText";
 import { SpotlightCard } from "@/components/reactbits/SpotlightCard";
 
@@ -19,9 +17,7 @@ const Home = () => {
     <div className="min-h-screen overflow-x-hidden">
       {/* Hero Section */}
       <section className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 sm:px-6">
-        {/* <SilkBackground /> */}
-        <LiquidEtherBackground />
-
+        
         {/* Content */}
         <div className="relative z-10 mx-auto w-full max-w-4xl text-center">
           <motion.div


### PR DESCRIPTION
## Summary
- wrap public routes with an AppLayout that renders the Liquid Ether background once and keeps navigation/content stacked above it
- update the Liquid Ether engine to listen for global pointer activity so the effect stays interactive beneath overlaying components
- remove the home-specific background usage now that the global layout controls the animated layer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27ab9be708322abcdd0644eb87432