### PR TITLE
feat: apply Liquid Ether background globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
-import { Navigation } from "./components/Navigation";
 import { ScrollToTop } from "./components/ScrollToTop";
+import AppLayout from "./components/AppLayout";
 import Home from "./pages/Home";
 import Portfolio from "./pages/Portfolio";
 import ArtworkDetail from "./pages/ArtworkDetail";
@@ -24,15 +24,16 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <ScrollToTop />
-          <Navigation />
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/portfolio" element={<Portfolio />} />
-            <Route path="/art/:slug" element={<ArtworkDetail />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="*" element={<NotFound />} />
+            <Route element={<AppLayout />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/portfolio" element={<Portfolio />} />
+              <Route path="/art/:slug" element={<ArtworkDetail />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/contact" element={<Contact />} />
+              <Route path="/auth" element={<Auth />} />
+              <Route path="*" element={<NotFound />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </TooltipProvider>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,0 +1,40 @@
+import { Outlet } from "react-router-dom";
+import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
+import { Navigation } from "@/components/Navigation";
+
+type AppLayoutProps = {
+  /**
+   * Allow routes to opt out of the animated background by rendering
+   * `<AppLayout showLiquidEther={false} />` in the router.
+   */
+  showLiquidEther?: boolean;
+};
+
+const AppLayout = ({ showLiquidEther = true }: AppLayoutProps) => {
+  return (
+    <div className="relative min-h-screen w-full overflow-hidden bg-[#05070f] text-slate-100">
+      {showLiquidEther ? (
+        <>
+          <LiquidEtherBackground />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-b from-[#05070f]/40 via-[#05070f]/55 to-[#05070f]/85"
+          />
+        </>
+      ) : (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-b from-[#05070f] via-[#04050b] to-[#03040a]"
+        />
+      )}
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <Navigation />
+        <main className="pointer-events-auto flex flex-1 flex-col">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/components/reactbits/LiquidEtherBackground.tsx
+++ b/src/components/reactbits/LiquidEtherBackground.tsx
@@ -12,7 +12,7 @@ const LiquidEtherBackground = () => {
   const palette = useMemo(() => ['#5227FF', '#FF9FFC', '#B19EEF'], []);
 
   return (
-    <div className="absolute inset-0" role="presentation" aria-hidden>
+    <div className="pointer-events-none absolute inset-0 -z-10" role="presentation" aria-hidden>
       {reduceMotion ? (
         <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-[#1a1033] via-[#0a0d1f] to-[#06121f]">
           <div
@@ -40,6 +40,8 @@ const LiquidEtherBackground = () => {
           takeoverDuration={0.25}
           autoResumeDelay={3000}
           autoRampDuration={0.6}
+          useGlobalListeners
+          className="pointer-events-none"
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- introduce an application layout that layers the Liquid Ether background behind every public route and keeps navigation/content above it
- update the Liquid Ether shader to support global pointer listeners so the animation remains interactive under page content and expose a layout escape hatch
- ensure the background container ignores pointer events while keeping accessibility fallbacks for reduced motion users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27ab9be708322abcdd0644eb87432