### PR TITLE
Optimize Liquid Ether background loading and motion preferences

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,67 @@
+# Auditoria da branch `add-liquid-ether-background-globally`
+
+## Visão geral
+- Escopo verificado: integração do `LiquidEtherBackground`, hooks Supabase (artworks, pages, settings, expositions, mensagens de contato), formulário de contato, design system/acessibilidade, desempenho do bundle, estrutura/código morto e alinhamento com RLS.
+- Ferramentas utilizadas: análise estática do código-fonte, busca contextual e build de produção para aferir tamanho do bundle.
+
+## Tarefas de correção propostas
+
+1. **Mitigar peso do bundle inicial gerado pelo Liquid Ether**  
+   - **Prioridade:** Alta · **Tipo:** Performance  
+   - **Local:** `src/App.tsx` (importação estática), `src/components/reactbits/LiquidEtherBackground.tsx`, relatório de build  
+   - **Problema:** O build de produção gera um chunk JS de ~1,23 MB (gzip 354 kB), muito acima da meta < 170 kB, porque o `LiquidEtherBackground` (que embute `three` + shaders) é importado estaticamente e carregado em todas as rotas públicas.  
+   - **Impacto:** Tempo de carregamento inicial elevado e queda no Core Web Vitals, especialmente em conexões móveis.  
+   - **Solução proposta:** Converter o background para `React.lazy`/`Suspense` com fallback estático (gradiente) e/ou usar `import()` condicionado a `prefers-reduced-motion`/`IntersectionObserver`, além de mover `three` para um chunk dedicado.  
+   - **Referências:** `App` monta o background globalmente【F:src/App.tsx†L1-L49】; o bundle excede 1 MB após minificação【81eb4f†L1-L10】.
+
+2. **Ajustar remoção dos event listeners no `LiquidEther`**  
+   - **Prioridade:** Média · **Tipo:** Bug  
+   - **Local:** `src/components/reactbits/LiquidEther.tsx` linhas 163–173  
+   - **Problema:** Os listeners de `mousemove`/`touch*` são adicionados com `{ passive: true }`, porém removidos com o terceiro parâmetro `false`, o que impede o `removeEventListener` de funcionar. Isso provoca múltiplos handlers ativos após hot-reload ou recriação do canvas.  
+   - **Impacto:** Vazamento de memória, degradação de performance e comportamento inconsistente do background em re-montagens.  
+   - **Solução proposta:** Persistir as mesmas opções (usar objeto constante ou `passive: true`) ao remover, garantindo detach correto durante `dispose()`.  
+   - **Referências:** Implementação atual de `init`/`dispose` do `MouseClass`【F:src/components/reactbits/LiquidEther.tsx†L140-L173】.
+
+3. **Tornar `SectionReveal` compatível com `prefers-reduced-motion`**  
+   - **Prioridade:** Média · **Tipo:** Acessibilidade  
+   - **Local:** `src/components/SectionReveal.tsx`  
+   - **Problema:** O componente aplica animações de entrada com `framer-motion` sem consultar `useReducedMotion`. Usuários que solicitam movimento reduzido continuam recebendo transições, contrariando WCAG 2.2.  
+   - **Impacto:** Experiência desconfortável para pessoas sensíveis a movimento; risco de não conformidade com políticas de acessibilidade.  
+   - **Solução proposta:** Integrar `useReducedMotion` para desativar animações (ou usar transições instantâneas) quando o usuário preferir movimento reduzido.  
+   - **Referências:** Animação fixa sem verificação de preferência【F:src/components/SectionReveal.tsx†L1-L25】.
+
+4. **Fortalecer validação acessível do formulário de contato**  
+   - **Prioridade:** Média · **Tipo:** Acessibilidade  
+   - **Local:** `src/pages/Contact.tsx`, `src/hooks/useContactForm.ts`  
+   - **Problema:** O formulário controla estado manualmente e delega erros ao toast global. A validação Zod dispara exceções, mas não há mensagens contextuais (`aria-live`, `role=alert`) nem `aria-invalid` nos campos. Usuários com leitor de tela não recebem feedback apropriado e quem desabilita toasts fica sem retorno.  
+   - **Impacto:** Violação de boas práticas de acessibilidade e possível perda de dados (usuário não sabe por que o envio falhou).  
+   - **Solução proposta:** Migrar para React Hook Form + `zodResolver`, exibir mensagens inline vinculadas via `<FormMessage>`/`aria-describedby`, e manter o toast apenas como complemento.  
+   - **Referências:** Implementação atual do form e da mutação Supabase【F:src/pages/Contact.tsx†L1-L172】【F:src/hooks/useContactForm.ts†L1-L44】.
+
+5. **Expor conteúdo dinâmico de `pages`/`settings` via hooks dedicados**  
+   - **Prioridade:** Média · **Tipo:** Refatoração  
+   - **Local:** Diretório `src/hooks` e páginas estáticas  
+   - **Problema:** Apenas artworks/exhibitions/contact usam hooks. Não há consultas para tabelas `pages`/`settings`; a home e demais páginas exibem texto hardcoded, exigindo deploy para ajustes editoriais.  
+   - **Impacto:** Equipe de conteúdo depende de releases para mudanças simples; integrações CMS/Supabase ficam subutilizadas.  
+   - **Solução proposta:** Criar hooks tipados (`usePage`, `useSettings`) com cache React Query e consumir nos componentes relevantes (Hero, metadata, CTAs), permitindo que o painel Supabase controle conteúdo.  
+   - **Referências:** Hooks existentes limitam-se a artworks/exhibitions/contact【503ff4†L1-L2】; não há queries `pages`/`settings` no código【53ede6†L1-L2】【1caebd†L1-L2】; Home mantém copy estático【F:src/pages/Home.tsx†L1-L134】.
+
+6. **Remover/arquivar `SilkBackground` não utilizado**  
+   - **Prioridade:** Baixa · **Tipo:** Refatoração  
+   - **Local:** `src/components/reactbits/SilkBackground.tsx`  
+   - **Problema:** O componente permanece no código sem ser importado (apenas citado no README), aumentando a superfície de manutenção e confundindo novas contribuições.  
+   - **Impacto:** Código morto dificulta rastrear a variante vigente do background e aumenta o custo cognitivo.  
+   - **Solução proposta:** Excluir o arquivo ou mover para exemplos/documentação, garantindo que só `LiquidEther` seja mantido no bundle.  
+   - **Referências:** Implementação residual do SilkBackground【F:src/components/reactbits/SilkBackground.tsx†L1-L60】; busca sem usos no app【e3466e†L1-L7】.
+
+7. **Usar `isAdmin` para alinhar visualização de rascunhos às policies de RLS**  
+   - **Prioridade:** Média · **Tipo:** Bug  
+   - **Local:** `src/hooks/useArtwork.ts`, `src/contexts/AuthContext.tsx`  
+   - **Problema:** O hook `useArtwork` não diferencia usuários autenticados; ele pede qualquer slug sem filtrar `status`, enquanto o contexto calcula `isAdmin` mas ninguém consome essa flag. Assim, admins não conseguem pré-visualizar rascunhos (pois o hook de lista filtra `published`) e visitantes dependem de erros de RLS para bloquear conteúdo.  
+   - **Impacto:** Fluxo editorial inconsistente: admins não veem rascunhos no front, e mensagens de erro do Supabase podem vazar para usuários finais.  
+   - **Solução proposta:** Injetar `isAdmin` nos hooks (`useArtwork`/`useArtworks`) para decidir filtros (`eq('status','published')` para público, sem filtro para admin) e tratar `403` com mensagem amigável.  
+   - **Referências:** Hook ignora `status` e não usa `isAdmin`【F:src/hooks/useArtwork.ts†L1-L18】; contexto expõe `isAdmin` mas não há consumidores além do provider【4508c9†L1-L5】【F:src/contexts/AuthContext.tsx†L1-L155】.
+
+---
+
+**Observação:** Nenhuma correção foi aplicada neste commit; o arquivo contém apenas recomendações de auditoria.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { Suspense, lazy } from "react";
+import { useReducedMotion } from "framer-motion";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -6,7 +8,6 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 import { Navigation } from "./components/Navigation";
 import { ScrollToTop } from "./components/ScrollToTop";
-import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
 import Home from "./pages/Home";
 import Portfolio from "./pages/Portfolio";
 import ArtworkDetail from "./pages/ArtworkDetail";
@@ -14,6 +15,39 @@ import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
+
+const LazyLiquidEtherBackground = lazy(
+  () => import("@/components/reactbits/LiquidEtherBackground"),
+);
+
+const BackgroundFallback = () => (
+  <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-[#1a1033] via-[#0a0d1f] to-[#06121f]">
+    <div
+      className="absolute inset-0"
+      style={{
+        backgroundImage:
+          "radial-gradient(at 20% 20%, rgba(109, 76, 255, 0.25), transparent 55%)," +
+          "radial-gradient(at 80% 10%, rgba(64, 134, 255, 0.18), transparent 60%)," +
+          "radial-gradient(at 50% 80%, rgba(180, 90, 255, 0.12), transparent 55%)",
+      }}
+    />
+    <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#0a0d1f]/60 to-[#060913]" />
+  </div>
+);
+
+const BackgroundLayer = () => {
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return <BackgroundFallback />;
+  }
+
+  return (
+    <Suspense fallback={<BackgroundFallback />}>
+      <LazyLiquidEtherBackground />
+    </Suspense>
+  );
+};
 
 const queryClient = new QueryClient();
 
@@ -32,7 +66,7 @@ const App = () => (
                 To disable it for a specific page in the future, read `useLocation()` and
                 conditionally render this block based on the current pathname.
               */}
-              <LiquidEtherBackground />
+              <BackgroundLayer />
             </div>
             <Navigation />
             <main className="relative z-0 flex-1">

--- a/src/components/SectionReveal.tsx
+++ b/src/components/SectionReveal.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { ReactNode } from "react";
 
 interface SectionRevealProps {
@@ -8,16 +8,23 @@ interface SectionRevealProps {
 }
 
 export const SectionReveal = ({ children, delay = 0, className = "" }: SectionRevealProps) => {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 40 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "-100px" }}
-      transition={{
+  const prefersReducedMotion = useReducedMotion();
+  const initial = prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 40 };
+  const whileInView = { opacity: 1, y: 0 };
+  const transition = prefersReducedMotion
+    ? { duration: 0 }
+    : {
         duration: 0.6,
         delay,
         ease: [0.4, 0, 0.2, 1],
-      }}
+      };
+
+  return (
+    <motion.div
+      initial={initial}
+      whileInView={whileInView}
+      viewport={{ once: true, margin: "-100px" }}
+      transition={transition}
       className={className}
     >
       {children}

--- a/src/components/reactbits/LiquidEther.tsx
+++ b/src/components/reactbits/LiquidEther.tsx
@@ -145,6 +145,7 @@ export default function LiquidEther({
         this._onTouchStart = this.onDocumentTouchStart.bind(this);
         this._onTouchMove = this.onDocumentTouchMove.bind(this);
         this._onTouchEnd = this.onTouchEnd.bind(this);
+        this.listenerOptions = { passive: true };
         this.isHoverInside = false;
         this.hasUserControl = false;
         this.isAutoActive = false;
@@ -160,17 +161,17 @@ export default function LiquidEther({
         this.container = container;
         if (typeof window === 'undefined') return;
         this.eventTarget = window;
-        this.eventTarget.addEventListener('mousemove', this._onMouseMove, { passive: true });
-        this.eventTarget.addEventListener('touchstart', this._onTouchStart, { passive: true });
-        this.eventTarget.addEventListener('touchmove', this._onTouchMove, { passive: true });
-        this.eventTarget.addEventListener('touchend', this._onTouchEnd, { passive: true });
+        this.eventTarget.addEventListener('mousemove', this._onMouseMove, this.listenerOptions);
+        this.eventTarget.addEventListener('touchstart', this._onTouchStart, this.listenerOptions);
+        this.eventTarget.addEventListener('touchmove', this._onTouchMove, this.listenerOptions);
+        this.eventTarget.addEventListener('touchend', this._onTouchEnd, this.listenerOptions);
       }
       dispose() {
         if (!this.eventTarget) return;
-        this.eventTarget.removeEventListener('mousemove', this._onMouseMove, false);
-        this.eventTarget.removeEventListener('touchstart', this._onTouchStart, false);
-        this.eventTarget.removeEventListener('touchmove', this._onTouchMove, false);
-        this.eventTarget.removeEventListener('touchend', this._onTouchEnd, false);
+        this.eventTarget.removeEventListener('mousemove', this._onMouseMove, this.listenerOptions);
+        this.eventTarget.removeEventListener('touchstart', this._onTouchStart, this.listenerOptions);
+        this.eventTarget.removeEventListener('touchmove', this._onTouchMove, this.listenerOptions);
+        this.eventTarget.removeEventListener('touchend', this._onTouchEnd, this.listenerOptions);
       }
       setCoords(x, y) {
         if (!this.container) return;


### PR DESCRIPTION
## Summary
- lazy load the Liquid Ether background with a gradient fallback when reduced motion is requested
- ensure the LiquidEther pointer event listeners clean up with matching passive options
- respect prefers-reduced-motion within the SectionReveal animation helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27c92e7b883229633709726317e29