### PR TITLE
Refine mobile navigation experience

### DIFF
--- a/src/components/reactbits/FlowingMenu.tsx
+++ b/src/components/reactbits/FlowingMenu.tsx
@@ -109,12 +109,13 @@ const MenuItem: React.FC<MenuItemProps> = ({ href, label, accent, isActive, redu
       <Link
         to={href}
         className={cn(
-          "flex h-full min-h-[64px] w-full items-center justify-center px-6 py-4 text-lg font-semibold uppercase transition-colors",
+          "flex h-full min-h-[64px] w-full items-center justify-center px-6 py-4 text-lg font-semibold uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
           isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground",
         )}
         onMouseEnter={handleEnter}
         onMouseLeave={handleLeave}
         onClick={onItemClick}
+        aria-current={isActive ? "page" : undefined}
       >
         {label}
       </Link>
@@ -137,7 +138,10 @@ export const FlowingMenu: React.FC<FlowingMenuProps> = ({ items, activeHref, onI
 
   return (
     <div className={cn("w-full overflow-hidden", className)}>
-      <nav className="flex flex-col overflow-hidden rounded-3xl border border-border/60 bg-surface-1/80 backdrop-blur-xl">
+      <nav
+        className="flex flex-col overflow-hidden rounded-3xl border border-border/60 bg-surface-1/90 backdrop-blur-xl"
+        aria-label="Mobile"
+      >
         {items.map((item) => (
           <MenuItem
             key={item.href}

--- a/src/components/reactbits/GooeyNav.tsx
+++ b/src/components/reactbits/GooeyNav.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Menu, X, LogIn, LogOut, User } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { FlowingMenu } from "./FlowingMenu";
@@ -36,110 +36,150 @@ export const GooeyNav = () => {
   const reduceMotion = useReducedMotion();
   const { user, isAdmin, signOut } = useAuth();
 
+  const menuId = "mobile-navigation";
+
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
   const isActive = (href: string) => location.pathname === href;
+
+  const toggleMenu = () => setOpen((prev) => !prev);
+  const closeMenu = () => setOpen(false);
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6 sm:pt-6">
-      <nav
-        className={cn(
-          "mx-auto flex w-full max-w-5xl rounded-full border border-border/70 bg-background/70 px-4 py-2 backdrop-blur-xl motion-reduce:transition-none min-h-[3.5rem] md:flex-row md:items-center md:justify-between",
-          open ? "flex-col items-stretch gap-y-3" : "flex-row items-center gap-2 justify-between",
-        )}
-      >
-        <div className="flex w-full items-center justify-between">
-          <Link
-            to="/"
-            className="flex min-w-0 items-center gap-2 py-2"
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="relative">
+          <nav
+            className={cn(
+              "flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-4 py-2 backdrop-blur-xl motion-reduce:transition-none min-h-[3.5rem]",
+              "shadow-[0_12px_45px_rgba(15,23,42,0.45)]",
+            )}
+            aria-label="Main"
           >
-            <span className="whitespace-nowrap text-[clamp(1.1rem,4vw,1.5rem)] font-semibold text-foreground">
-              Art Leo
-            </span>
-          </Link>
-          <button
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-card/70 p-2 text-foreground motion-reduce:transition-none md:hidden"
-            onClick={() => setOpen((prev) => !prev)}
-            aria-label="Toggle navigation"
-            aria-expanded={open}
-          >
-            {open ? <X /> : <Menu />}
-          </button>
-        </div>
-        <div className="hidden items-center gap-3 md:flex">
-          {links.map((link) => (
-            <motion.div key={link.href} className="relative">
-              <Link
-                to={link.href}
-                className={cn(
-                    "relative inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors",
-                    isActive(link.href)
-                      ? "text-primary"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {link.label}
-                </Link>
-                {isActive(link.href) && (
-                  <motion.span
-                    layoutId="gooey-active"
-                    className="pointer-events-none absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary/30 via-secondary/20 to-primary/30 blur-xl"
-                    transition={{ type: "spring", stiffness: 260, damping: 28 }}
-                  />
-                )}
-              </motion.div>
-            ))}
-            
-            {/* Auth Section */}
-            {user ? (
-              <div className="flex items-center gap-2 ml-2 pl-2 border-l border-border/50">
-                {isAdmin && (
-                  <Link to="/admin">
+            <Link
+              to="/"
+              className="flex min-w-0 items-center gap-2 py-2"
+            >
+              <span className="whitespace-nowrap text-[clamp(1.1rem,4vw,1.5rem)] font-semibold text-foreground">
+                Art Leo
+              </span>
+            </Link>
+            <div className="ml-auto flex items-center gap-3">
+              <div className="hidden items-center gap-3 md:flex">
+                {links.map((link) => (
+                  <motion.div key={link.href} className="relative">
+                    <Link
+                      to={link.href}
+                      className={cn(
+                        "relative inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors",
+                        isActive(link.href)
+                          ? "text-primary"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {link.label}
+                    </Link>
+                    {isActive(link.href) && (
+                      <motion.span
+                        layoutId="gooey-active"
+                        className="pointer-events-none absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary/30 via-secondary/20 to-primary/30 blur-xl"
+                        transition={{ type: "spring", stiffness: 260, damping: 28 }}
+                      />
+                    )}
+                  </motion.div>
+                ))}
+
+                {/* Auth Section */}
+                {user ? (
+                  <div className="ml-2 flex items-center gap-2 border-l border-border/50 pl-2">
+                    {isAdmin && (
+                      <Link to="/admin">
+                        <Button variant="ghost" size="sm" className="gap-2">
+                          <User className="h-4 w-4" />
+                          Admin
+                        </Button>
+                      </Link>
+                    )}
+                    <Button variant="ghost" size="sm" onClick={() => signOut()} className="gap-2">
+                      <LogOut className="h-4 w-4" />
+                      Logout
+                    </Button>
+                  </div>
+                ) : (
+                  <Link to="/auth" className="ml-2 border-l border-border/50 pl-2">
                     <Button variant="ghost" size="sm" className="gap-2">
-                      <User className="h-4 w-4" />
-                      Admin
+                      <LogIn className="h-4 w-4" />
+                      Login
                     </Button>
                   </Link>
                 )}
-                <Button variant="ghost" size="sm" onClick={() => signOut()} className="gap-2">
-                  <LogOut className="h-4 w-4" />
-                  Logout
-                </Button>
               </div>
-            ) : (
-              <Link to="/auth" className="ml-2 pl-2 border-l border-border/50">
-                <Button variant="ghost" size="sm" className="gap-2">
-                  <LogIn className="h-4 w-4" />
-                  Login
-                </Button>
-              </Link>
-            )}
-          </div>
-        <button
-          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-surface-1/70 p-2 text-foreground motion-reduce:transition-none md:hidden"
-          onClick={() => setOpen((prev) => !prev)}
-          aria-label="Toggle navigation"
-          aria-expanded={open}
-        >
-            {open ? <X /> : <Menu />}
-        </button>
+              <button
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-card/70 p-2 text-foreground transition-colors hover:border-primary/80 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none md:hidden"
+                onClick={toggleMenu}
+                aria-controls={menuId}
+                aria-expanded={open}
+                aria-haspopup="true"
+                aria-label={open ? "Close navigation" : "Open navigation"}
+              >
+                {open ? <X /> : <Menu />}
+              </button>
+            </div>
+          </nav>
 
-        <AnimatePresence>
-          {open && (
-            <motion.div
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: "auto", opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: reduceMotion ? 0 : 0.4, ease: [0.21, 1, 0.29, 1] }}
-              className="mt-3 w-full basis-full flex-shrink-0 md:hidden"
-            >
-              <FlowingMenu
-                items={links}
-                activeHref={location.pathname}
-                onItemClick={() => setOpen(false)}
-              />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </nav>
+          <AnimatePresence>
+            {open && (
+              <motion.div
+                key="mobile-menu"
+                id={menuId}
+                initial={{ opacity: 0, y: -12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: reduceMotion ? 0 : 0.24, ease: [0.16, 1, 0.3, 1] }}
+                className="absolute inset-x-0 top-full z-50 mt-3 md:hidden"
+              >
+                <FlowingMenu
+                  items={links}
+                  activeHref={location.pathname}
+                  onItemClick={closeMenu}
+                  className="shadow-[0_20px_60px_rgba(15,23,42,0.45)]"
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {open && (
+          <motion.button
+            key="mobile-overlay"
+            type="button"
+            aria-hidden="true"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.24, ease: "linear" }}
+            className="fixed inset-0 z-40 bg-background/80 backdrop-blur-sm md:hidden"
+            onClick={closeMenu}
+          />
+        )}
+      </AnimatePresence>
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- refactor the GooeyNav layout so the mobile hamburger controls a single menu with an overlay and escape-key dismissal
- ensure the FlowingMenu is positioned below the header with smooth animation and closes on navigation changes
- add accessibility improvements including aria attributes, focus-visible styles, and mobile nav labelling

## Testing
- npm run lint *(fails: pre-existing lint errors in LiquidEther.tsx and hooks/useSettings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e790ec19548322857b5f5566ec6acd