### PR TITLE
Fix mobile artwork CTA visibility and clean build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ npm run lint
 
 Linting ensures TypeScript, React, and accessibility conventions stay consistent.
 
+### Troubleshooting
+
+- If the CLI prints `npm warn Unknown env config "http-proxy"`, clear any inherited proxy variables before running the scripts:
+
+  ```bash
+  unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY
+  ```
+
+  The project itself does not configure a proxy; the warning stems from globally exported environment variables.
+
 ## Project structure
 
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "src/components/reactbits/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],
@@ -19,7 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-refresh/only-export-components": "off",
       "@typescript-eslint/no-unused-vars": "off",
     },
   },

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode } from "react";
+import { Component, ReactNode, ErrorInfo } from "react";
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
 
@@ -22,7 +22,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: any) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 

--- a/src/hooks/usePages.ts
+++ b/src/hooks/usePages.ts
@@ -1,12 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/integrations/supabase/types";
 
-interface PageContent {
-  title: string;
-  content: any;
-  meta_title?: string;
-  meta_description?: string;
-}
+type PageContent = Tables<"pages">;
 
 export const usePages = (slug?: string) => {
   return useQuery({

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,11 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import type { Json, Tables } from "@/integrations/supabase/types";
 
-interface Setting {
-  key: string;
-  value: any;
-  description?: string;
-}
+type Setting = Tables<"settings">;
 
 export const useSettings = (key?: string) => {
   return useQuery({
@@ -36,8 +33,8 @@ export const useSettings = (key?: string) => {
   });
 };
 
-export const useSiteSetting = (key: string, fallback: any = null) => {
+export const useSiteSetting = <T = Json | null>(key: string, fallback: T) => {
   const { data } = useSettings(key);
   if (Array.isArray(data)) return fallback;
-  return data?.value ?? fallback;
+  return (data?.value as T | undefined) ?? fallback;
 };

--- a/src/pages/ArtworkDetail.tsx
+++ b/src/pages/ArtworkDetail.tsx
@@ -136,12 +136,15 @@ const ArtworkDetail = () => {
             )}
 
             <SectionReveal delay={0.4}>
-              <div className="pt-4">
-                <Link to="/contact">
-                  <Button variant="hero" size="lg" className="w-full sm:w-auto">
-                    Inquire About This Work
-                  </Button>
-                </Link>
+              <div className="pt-4 flex justify-center sm:justify-start">
+                <Button
+                  asChild
+                  variant="hero"
+                  size="lg"
+                  className="w-full sm:w-auto"
+                >
+                  <Link to="/contact">Inquire About This Work</Link>
+                </Button>
               </div>
             </SectionReveal>
           </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,79 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) {
+            return undefined;
+          }
+
+          if (id.includes("three") || id.includes("@react-three")) {
+            return "three";
+          }
+
+          if (id.includes("framer-motion")) {
+            return "framer-motion";
+          }
+
+          if (id.includes("react-router-dom")) {
+            return "router";
+          }
+
+          if (id.includes("@tanstack")) {
+            return "tanstack";
+          }
+
+          if (id.includes("react-dom") || id.includes("scheduler")) {
+            return "react-dom";
+          }
+
+          if (id.includes("@radix-ui")) {
+            return "radix";
+          }
+
+          if (id.includes("lucide-react")) {
+            return "icons";
+          }
+
+          if (id.includes("recharts")) {
+            return "recharts";
+          }
+
+          if (id.includes("gsap")) {
+            return "gsap";
+          }
+
+          if (id.includes("zustand")) {
+            return "zustand";
+          }
+
+          if (id.includes("cmdk")) {
+            return "cmdk";
+          }
+
+          if (id.includes("sonner")) {
+            return "sonner";
+          }
+
+          if (id.includes("date-fns")) {
+            return "date-fns";
+          }
+
+          if (id.includes("react-hook-form") || id.includes("@hookform")) {
+            return "react-hook-form";
+          }
+
+          if (id.includes("zod")) {
+            return "zod";
+          }
+
+          return "vendor";
+        },
+      },
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary
- ensure linting skips vendored React Bits code and quiets the dev-only export warning
- use generated Supabase types, tighten the error boundary signature, and document how to silence inherited proxy warnings
- render the artwork inquiry CTA with `asChild` button markup and split large Vite chunks to eliminate the build warning

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7a719676c8322b7bd5adbee57df15