### PR TITLE
Improve build reliability and mobile CTA layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react-swc": "^3.11.0",
         "autoprefixer": "^10.4.21",
+        "cross-env": "^10.1.0",
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -279,6 +280,13 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2550,6 +2558,24 @@
         }
       }
     },
+    "node_modules/@react-three/drei/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/@react-three/drei/node_modules/zustand": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
@@ -4487,21 +4513,21 @@
       "license": "MIT"
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "build:dev": "vite build --mode development",
+    "build": "cross-env npm_config_http_proxy= npm_config_https_proxy= npm_config_proxy= node scripts/run-vite-build.mjs",
+    "build:dev": "cross-env npm_config_http_proxy= npm_config_https_proxy= npm_config_proxy= node scripts/run-vite-build.mjs --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
@@ -83,6 +83,7 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^10.1.0",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/scripts/run-vite-build.mjs
+++ b/scripts/run-vite-build.mjs
@@ -1,0 +1,31 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const sanitizedEnv = { ...process.env };
+
+for (const key of [
+  "npm_config_http-proxy",
+  "npm_config_http_proxy",
+  "npm_config_https-proxy",
+  "npm_config_https_proxy",
+  "npm_config_proxy",
+]) {
+  if (key in sanitizedEnv) {
+    delete sanitizedEnv[key];
+  }
+}
+
+const viteCli = fileURLToPath(new URL("../node_modules/vite/bin/vite.js", import.meta.url));
+
+const cliArgs = [viteCli, "build", ...process.argv.slice(2)];
+
+const child = spawn(process.execPath, cliArgs, {
+  cwd: path.resolve(fileURLToPath(new URL("../", import.meta.url))),
+  env: sanitizedEnv,
+  stdio: "inherit",
+});
+
+child.on("close", (code) => {
+  process.exit(code ?? 0);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -6,13 +7,15 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 import { Navigation } from "./components/Navigation";
 import { ScrollToTop } from "./components/ScrollToTop";
-import Home from "./pages/Home";
-import Portfolio from "./pages/Portfolio";
-import ArtworkDetail from "./pages/ArtworkDetail";
-import About from "./pages/About";
-import Contact from "./pages/Contact";
-import Auth from "./pages/Auth";
-import NotFound from "./pages/NotFound";
+import { PageLoader } from "./components/PageLoader";
+
+const Home = lazy(() => import("./pages/Home"));
+const Portfolio = lazy(() => import("./pages/Portfolio"));
+const ArtworkDetail = lazy(() => import("./pages/ArtworkDetail"));
+const About = lazy(() => import("./pages/About"));
+const Contact = lazy(() => import("./pages/Contact"));
+const Auth = lazy(() => import("./pages/Auth"));
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
 
@@ -25,15 +28,17 @@ const App = () => (
         <BrowserRouter>
           <ScrollToTop />
           <Navigation />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/portfolio" element={<Portfolio />} />
-            <Route path="/art/:slug" element={<ArtworkDetail />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <Suspense fallback={<PageLoader />}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/portfolio" element={<Portfolio />} />
+              <Route path="/art/:slug" element={<ArtworkDetail />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/contact" element={<Contact />} />
+              <Route path="/auth" element={<Auth />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </BrowserRouter>
       </TooltipProvider>
     </AuthProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode } from "react";
+import { Component, ReactNode, type ErrorInfo } from "react";
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
 
@@ -22,7 +22,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: any) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -1,0 +1,14 @@
+import { Loader2 } from "lucide-react";
+
+export const PageLoader = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-24 text-muted-foreground">
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden />
+        <p className="text-sm font-medium">Loading the experience…</p>
+      </div>
+    </div>
+  );
+};
+
+PageLoader.displayName = "PageLoader";

--- a/src/components/reactbits/LiquidEther.tsx
+++ b/src/components/reactbits/LiquidEther.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
@@ -783,7 +784,7 @@ export default function LiquidEther({
           wrapS: THREE.ClampToEdgeWrapping,
           wrapT: THREE.ClampToEdgeWrapping
         };
-        for (let key in this.fbos) {
+        for (const key in this.fbos) {
           this.fbos[key] = new THREE.WebGLRenderTarget(this.fboSize.x, this.fboSize.y, opts);
         }
       }
@@ -842,7 +843,7 @@ export default function LiquidEther({
       }
       resize() {
         this.calcSize();
-        for (let key in this.fbos) {
+        for (const key in this.fbos) {
           this.fbos[key].setSize(this.fboSize.x, this.fboSize.y);
         }
       }

--- a/src/hooks/usePages.ts
+++ b/src/hooks/usePages.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { JsonValue } from "@/types/json";
 
 interface PageContent {
   title: string;
-  content: any;
+  content: JsonValue;
   meta_title?: string;
   meta_description?: string;
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { JsonValue } from "@/types/json";
 
 interface Setting {
   key: string;
-  value: any;
+  value: JsonValue;
   description?: string;
 }
 
@@ -36,8 +37,8 @@ export const useSettings = (key?: string) => {
   });
 };
 
-export const useSiteSetting = (key: string, fallback: any = null) => {
+export const useSiteSetting = (key: string, fallback: JsonValue | null = null) => {
   const { data } = useSettings(key);
   if (Array.isArray(data)) return fallback;
-  return data?.value ?? fallback;
+  return (data?.value ?? fallback) ?? null;
 };

--- a/src/pages/ArtworkDetail.tsx
+++ b/src/pages/ArtworkDetail.tsx
@@ -74,7 +74,7 @@ const ArtworkDetail = () => {
           </SectionReveal>
 
           {/* Details */}
-          <div className="space-y-8">
+          <div className="flex flex-col gap-8 lg:gap-10">
             <SectionReveal delay={0.1}>
               <div>
                 <h1 className="mb-4 text-[clamp(1.85rem,6vw,3.25rem)] font-bold leading-tight text-balance">
@@ -135,10 +135,10 @@ const ArtworkDetail = () => {
               </SectionReveal>
             )}
 
-            <SectionReveal delay={0.4}>
-              <div className="pt-4">
-                <Link to="/contact">
-                  <Button variant="hero" size="lg" className="w-full sm:w-auto">
+            <SectionReveal delay={0.4} className="mt-auto">
+              <div className="pt-4 sm:pt-6">
+                <Link to="/contact" className="block w-full sm:w-auto">
+                  <Button variant="hero" size="lg" className="w-full">
                     Inquire About This Work
                   </Button>
                 </Link>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,9 @@
+import { lazy, Suspense } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { SectionReveal } from "@/components/SectionReveal";
 import { ArrowRight, Sparkles, Palette, Eye } from "lucide-react";
 import { motion } from "framer-motion";
-import LiquidEtherBackground from "@/components/reactbits/LiquidEtherBackground";
 import { SplitText } from "@/components/reactbits/SplitText";
 import { SpotlightCard } from "@/components/reactbits/SpotlightCard";
 import { PixelCard } from "@/components/reactbits/PixelCard";
@@ -12,6 +12,26 @@ import { useSiteSetting } from "@/hooks/useSettings";
 import { useArtworks } from "@/hooks/useArtworks";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ArtworkSkeleton } from "@/components/ArtworkSkeleton";
+
+const LiquidEtherBackground = lazy(() => import("@/components/reactbits/LiquidEtherBackground"));
+
+const HeroBackgroundFallback = () => (
+  <div
+    className="absolute inset-0 overflow-hidden bg-gradient-to-br from-[#1a1033] via-[#0a0d1f] to-[#06121f]"
+    aria-hidden
+  >
+    <div
+      className="absolute inset-0"
+      style={{
+        backgroundImage:
+          "radial-gradient(at 20% 20%, rgba(109, 76, 255, 0.25), transparent 55%)," +
+          "radial-gradient(at 80% 10%, rgba(64, 134, 255, 0.18), transparent 60%)," +
+          "radial-gradient(at 50% 80%, rgba(180, 90, 255, 0.12), transparent 55%)",
+      }}
+    />
+    <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#0a0d1f]/60 to-[#060913]" />
+  </div>
+);
 
 const FEATURED_DISCIPLINES = [
   { icon: Palette, title: "Motion Design", desc: "Dynamic visual narratives" },
@@ -27,8 +47,9 @@ const Home = () => {
     <div className="min-h-screen overflow-x-hidden">
       {/* Hero Section */}
       <section className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 sm:px-6">
-        {/* <SilkBackground /> */}
-        <LiquidEtherBackground />
+        <Suspense fallback={<HeroBackgroundFallback />}>
+          <LiquidEtherBackground />
+        </Suspense>
 
         {/* Content */}
         <div className="relative z-10 mx-auto w-full max-w-4xl text-center">
@@ -118,7 +139,7 @@ const Home = () => {
               <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
                 {featuredArtworks.slice(0, 3).map((artwork, index) => (
                   <SectionReveal key={artwork.id} delay={index * 0.1}>
-                    <Link to={`/portfolio/${artwork.slug}`}>
+                    <Link to={`/art/${artwork.slug}`}>
                       <PixelCard
                         title={artwork.title}
                         imageUrl={artwork.cover_url}

--- a/src/types/json.ts
+++ b/src/types/json.ts
@@ -1,0 +1,7 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,37 @@ export default defineConfig(() => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules")) {
+            if (id.includes("three")) {
+              return "chunk-three";
+            }
+
+            if (id.includes("framer-motion")) {
+              return "chunk-framer-motion";
+            }
+
+            if (id.includes("@supabase")) {
+              return "chunk-supabase";
+            }
+
+            if (id.includes("lucide-react")) {
+              return "chunk-icons";
+            }
+
+            if (id.includes("@tanstack")) {
+              return "chunk-query";
+            }
+          }
+
+          return undefined;
+        },
+      },
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary
- lazy-load route modules and the Liquid Ether hero background while providing a reusable page loader
- adjust the artwork detail layout and homepage links so the inquiry CTA stays visible on mobile and routes point to existing pages
- add a build wrapper that clears proxy env vars, introduce vendor chunk splitting, and tighten Supabase hook typing for clean builds

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8f90c02b4832282698bf2e726f1b8